### PR TITLE
hard linking docs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ taegis --help
 
 ## Sample Usage
 
-For more in depth examples see [docs](docs/README.md).
+For more in depth examples see [docs](https://github.com/secureworks/taegis-magic/blob/main/docs/README.md).
 
 ### CLI
 


### PR DESCRIPTION
The description page for PyPI attempts to soft link to `https://pypi.org/project/taegis-magic/docs/README.md`.  This page doesn't exist.  Hard linking the URL will keep the Github functionality while fixing the Pypi page.

See https://pypi.org/project/taegis-magic/

```
Sample Usage
For more in depth examples see [docs](https://pypi.org/project/taegis-magic/docs/README.md).
```

closes #9 