### PR TITLE
Remove Gen AI field from Rules Output + Add pagination to rules search

### DIFF
--- a/taegis_magic/commands/rules.py
+++ b/taegis_magic/commands/rules.py
@@ -10,6 +10,7 @@ from dataclasses_json import dataclass_json
 from taegis_magic.core.log import tracing
 from taegis_magic.core.normalizer import TaegisResultsNormalizer
 from taegis_magic.core.service import get_service
+from taegis_magic.core.utils import remove_output_node
 from taegis_sdk_python import (
     GraphQLNoRowsInResultSetError,
     build_output_string,
@@ -69,6 +70,12 @@ RULE_SUPPRESSION_KEY_MAP = {
 }
 
 
+MULTIPLE_RULES_OUTPUT = remove_output_node(
+    build_output_string(Rule),
+    "generativeAIRuleExplain",
+)
+
+
 @dataclass_json
 @dataclass
 class TaegisRuleNormalizer(TaegisResultsNormalizer):
@@ -119,9 +126,10 @@ def rules_type(
 
     log.info(f"Getting page: {page}")
     try:
-        results = service.rules.query.rules(
-            page=page, count=per_page, rule_type=rule_type
-        )
+        with service(output=MULTIPLE_RULES_OUTPUT):
+            results = service.rules.query.rules(
+                page=page, count=per_page, rule_type=rule_type
+            )
     except GraphQLNoRowsInResultSetError:  # pragma: no cover
         results = []
     log.debug(f"Results returned: {len(results)}")
@@ -131,9 +139,10 @@ def rules_type(
         page += 1
         log.info(f"Getting page: {page}")
         try:
-            results = service.rules.query.rules(
-                page=page, count=per_page, rule_type=rule_type
-            )
+            with service(output=MULTIPLE_RULES_OUTPUT):
+                results = service.rules.query.rules(
+                    page=page, count=per_page, rule_type=rule_type
+                )
         except GraphQLNoRowsInResultSetError:  # pragma: no cover
             results = []
         log.debug(f"Results returned: {len(results)}")
@@ -162,11 +171,10 @@ def rules_all(
     page = 1
     per_page = 500
     rules = []
-    modified_output = build_output_string(Rule).replace("generativeAIRuleExplain", "")
 
     log.info(f"Getting page: {page}")
     try:
-        with service(output=modified_output):
+        with service(output=MULTIPLE_RULES_OUTPUT):
             results = service.rules.query.all_rules(page=page, count=per_page)
     except GraphQLNoRowsInResultSetError:  # pragma: no cover
         results = []
@@ -177,7 +185,7 @@ def rules_all(
         page += 1
         log.info(f"Getting page: {page}")
         try:
-            with service(output=modified_output):
+            with service(output=MULTIPLE_RULES_OUTPUT):
                 results = service.rules.query.all_rules(page=page, count=per_page)
         except GraphQLNoRowsInResultSetError:  # pragma: no cover
             results = []
@@ -259,13 +267,10 @@ def rules_deleted(
     page = 1
     per_page = 500
     rules = []
-    modified_output = build_output_string(SearchRulesOutput).replace(
-        "generativeAIRuleExplain", ""
-    )
 
     log.info(f"Getting page: {page}")
     try:
-        with service(output=modified_output):
+        with service(output=MULTIPLE_RULES_OUTPUT):
             results = service.rules.query.deleted_rules(
                 page=page,
                 count=per_page,
@@ -280,7 +285,7 @@ def rules_deleted(
         page += 1
         log.info(f"Getting page: {page}")
         try:
-            with service(output=modified_output):
+            with service(output=MULTIPLE_RULES_OUTPUT):
                 results = service.rules.query.deleted_rules(
                     page=page,
                     count=per_page,
@@ -316,13 +321,10 @@ def rules_event_type(
     page = 1
     per_page = 500
     rules = []
-    modified_output = build_output_string(SearchRulesOutput).replace(
-        "generativeAIRuleExplain", ""
-    )
 
     log.info(f"Getting page: {page}")
     try:
-        with service(output=modified_output):
+        with service(output=MULTIPLE_RULES_OUTPUT):
             results = service.rules.query.rules_for_event(
                 page=page, count=per_page, event_type=event_type, rule_type=rule_type
             )
@@ -335,7 +337,7 @@ def rules_event_type(
         page += 1
         log.info(f"Getting page: {page}")
         try:
-            with service(output=modified_output):
+            with service(output=MULTIPLE_RULES_OUTPUT):
                 results = service.rules.query.rules_for_event(
                     page=page,
                     count=per_page,
@@ -430,13 +432,9 @@ def rules_search(
     per_page = 500
     rules = []
 
-    modified_output = build_output_string(SearchRulesOutput).replace(
-        "generativeAIRuleExplain", ""
-    )
-
     log.info(f"Getting page: {page}")
     try:
-        with service(output=modified_output):
+        with service(output=MULTIPLE_RULES_OUTPUT):
             results = service.rules.query.search_rules(
                 SearchRulesInput(query=cell),
                 page=page,
@@ -451,7 +449,7 @@ def rules_search(
         page += 1
         log.info(f"Getting page: {page}")
         try:
-            with service(output=modified_output):
+            with service(output=MULTIPLE_RULES_OUTPUT):
                 results = service.rules.query.search_rules(
                     SearchRulesInput(query=cell),
                     page=page,


### PR DESCRIPTION
Issue 1:

Currently when using the Taegis Magics to get rules from the API, we get timeout errors due to side services not loading in time.

Issue 2:

For rules search, there is no pagination in place, so I've added that in.