### PR TITLE
Fix Event Search Cache

### DIFF
--- a/taegis_magic/_version.py
+++ b/taegis_magic/_version.py
@@ -1,3 +1,3 @@
 """Version identifier."""
 
-__version__ = "2024.10.7"
+__version__ = "2024.10.8"

--- a/taegis_magic/commands/events.py
+++ b/taegis_magic/commands/events.py
@@ -249,7 +249,14 @@ def search(
         service="events",
         tenant_id=service.tenant_id,
         region=service.environment,
-        arguments=inspect.currentframe().f_locals,
+        arguments={
+            "cell": cell,
+            "tenant": service.tenant_id,
+            "region": service.region,
+            "save": save,
+            "track": track,
+            "database": database,
+        },
         query=cell,
         is_saved=save,
     )


### PR DESCRIPTION
* Using `inspect.currentframe().f_locals` was inserting a GraphQLService object into the normalizer arguments and in certain environments causing the object to fail compressing into a pickle with the `--cache` flag used