### PR TITLE
ISSUE #68: Create Magic functions for Process Trees

### DIFF
--- a/taegis_magic/cli.py
+++ b/taegis_magic/cli.py
@@ -24,6 +24,7 @@ from taegis_magic.commands import (
     tenants,
     threat,
     users,
+    process_trees
 )
 from taegis_magic.core.normalizer import TaegisResult
 from dataclasses_json import dataclass_json
@@ -61,7 +62,7 @@ app.add_typer(tenant_profiles.app, name="tenant-profiles")
 app.add_typer(tenants.app, name="tenants")
 app.add_typer(threat.app, name="threat")
 app.add_typer(users.app, name="users")
-
+app.add_typer(process_trees.app, name="process-trees")
 
 CONFIG = configure.set_defaults()
 

--- a/taegis_magic/commands/process_trees.py
+++ b/taegis_magic/commands/process_trees.py
@@ -1,0 +1,119 @@
+import inspect
+import logging
+from typing import Optional
+
+import typer
+from typing_extensions import Annotated
+
+from dataclasses import asdict, dataclass, field
+from taegis_magic.core.log import tracing
+from taegis_magic.core.normalizer import TaegisResult
+from taegis_magic.core.service import get_service
+from taegis_magic.commands.events import search
+
+from taegis_magic.core.utils import to_dataframe
+
+app = typer.Typer(help="Taegis Subjects Commands.")
+
+log = logging.getLogger(__name__)
+
+from dataclasses import asdict, dataclass
+from taegis_magic.core.normalizer import TaegisResultsNormalizer
+from taegis_sdk_python.services.process_trees.types import ProcessLineage
+@dataclass
+class ProcessLineageNormalizer(TaegisResultsNormalizer):
+    """Normalizer for ProcessLineage results, as it is always a single dataclass result."""
+
+    raw_results: ProcessLineage = field(default_factory=lambda: ProcessLineage())
+
+    @property
+    def results(self):
+        rows = []
+        for result in self.raw_results if isinstance(self.raw_results, list) else [self.raw_results]:
+            if hasattr(result, "__dataclass_fields__"):
+                result_dict = asdict(result)
+            else:
+                result_dict = result
+            lineage = result_dict.get("lineage", [])
+            if lineage is None:
+                lineage = []
+            for idx, entry in enumerate(lineage):
+                row = {"lineage_index": idx}
+                if hasattr(entry, "__dataclass_fields__"):
+                    row.update(asdict(entry))
+                elif isinstance(entry, dict):
+                    row.update(entry)
+                rows.append(row)
+        return rows
+    
+@app.command()
+@tracing
+def process_lineage(
+    region: Annotated[Optional[str], typer.Option(help="Taegis region")] = None,
+    tenant_id: Annotated[Optional[str], typer.Option(help="Taegis tenant id")] = None,
+    host_id: Annotated[Optional[str], typer.Option(help="Taegis host id")] = None,
+    process_correlation_id: Annotated[Optional[str], typer.Option(help="Taegis Event process correlation id")] = None,
+    resource_id: Annotated[Optional[str], typer.Option(help="Taegis Event resource ID")] = None,
+):
+    """Get process lineage for a given region & tenant, based on the resource_id, host_id, and process_correlation_id."""
+    service = get_service(environment=region, tenant_id=tenant_id)
+
+    results = service.process_trees.query.process_lineage(host_id=host_id, process_correlation_id=process_correlation_id, tenant_id=tenant_id, resource_id=resource_id)
+
+    normalized_results = ProcessLineageNormalizer(
+        raw_results=results,
+        service="process_lineage",
+        tenant_id=service.tenant_id,
+        region=service.environment,
+        arguments=inspect.currentframe().f_locals,
+    )
+
+    return normalized_results
+
+@app.command()
+@tracing
+def process_children(
+        region: Annotated[Optional[str], typer.Option(help="Taegis region")] = None,
+        tenant_id: Annotated[Optional[str], typer.Option(help="Taegis tenant id")] = None,
+        host_id: Annotated[Optional[str], typer.Option(help="Taegis host id")] = None,
+        process_correlation_id: Annotated[Optional[str], typer.Option(help="Taegis Event process correlation id")] = None,
+        resource_id: Annotated[Optional[str], typer.Option(help="Taegis Event resource ID")] = None,
+):
+    """Get process children for a given region & tenant, based on the resource_id, host_id, and process_correlation_id."""
+    service = get_service(environment=region, tenant_id=tenant_id)
+    results = service.process_trees.query.process_children(host_id=host_id, process_correlation_id=process_correlation_id, tenant_id=tenant_id, resource_id=resource_id)
+
+    normalized_results = TaegisResult(
+        raw_results=results,
+        service="process_children",
+        tenant_id=service.tenant_id,
+        region=service.environment,
+        arguments=inspect.currentframe().f_locals,
+    )
+
+    return normalized_results
+
+
+@app.command()
+@tracing
+def process_parent(
+        region: Annotated[Optional[str], typer.Option(help="Taegis region")] = None,
+        tenant_id: Annotated[Optional[str], typer.Option(help="Taegis tenant id")] = None,
+        host_id: Annotated[Optional[str], typer.Option(help="Taegis host id")] = None,
+        parent_pcid: Annotated[Optional[str], typer.Option(help="Taegis Event process correlation id")] = None,
+        resource_id: Annotated[Optional[str], typer.Option(help="Taegis Event resource ID")] = None,
+):
+    """Gets the processes' parent based on the parent_correlation_id for a given region & tenant, based on the resource_id, host_id, and parent_process_correlation_id."""
+    service = get_service(environment=region, tenant_id=tenant_id)
+    results = service.process_trees.query.process_parent(host_id=host_id, parent_process_correlation_id=parent_pcid, tenant_id=tenant_id, resource_id=resource_id)
+
+    normalized_results = TaegisResult(
+        raw_results=results,
+        service="process_parent",
+        tenant_id=service.tenant_id,
+        region=service.environment,
+        arguments=inspect.currentframe().f_locals,
+    )
+
+    return normalized_results
+

--- a/taegis_magic/commands/process_trees.py
+++ b/taegis_magic/commands/process_trees.py
@@ -1,13 +1,13 @@
 import inspect
 import logging
-from typing import Optional
+from typing import Optional, List
 
 import typer
 from typing_extensions import Annotated
 
 from dataclasses import asdict, dataclass, field
 from taegis_magic.core.log import tracing
-from taegis_magic.core.normalizer import TaegisResult
+from taegis_magic.core.normalizer import TaegisResults, TaegisResult
 from taegis_magic.core.service import get_service                                               
 
 app = typer.Typer(help="Taegis Subjects Commands.")
@@ -16,7 +16,8 @@ log = logging.getLogger(__name__)
 
 from dataclasses import asdict, dataclass
 from taegis_magic.core.normalizer import TaegisResultsNormalizer
-from taegis_sdk_python.services.process_trees.types import ProcessLineage
+from taegis_sdk_python.services.process_trees.types import ProcessLineage, Children
+
 @dataclass
 class ProcessLineageNormalizer(TaegisResultsNormalizer):
     """Normalizer for ProcessLineage results, as it is always a single dataclass result."""
@@ -42,7 +43,9 @@ class ProcessLineageNormalizer(TaegisResultsNormalizer):
                     row.update(entry)
                 rows.append(row)
         return rows
-    
+
+
+
 @app.command()
 @tracing
 def process_lineage(
@@ -54,8 +57,9 @@ def process_lineage(
 ):
     """Get process lineage for a given region & tenant, based on the resource_id, host_id, and process_correlation_id."""
     service = get_service(environment=region, tenant_id=tenant_id)
-
+    
     results = service.process_trees.query.process_lineage(host_id=host_id, process_correlation_id=process_correlation_id, tenant_id=tenant_id, resource_id=resource_id)
+    # Process Lineage does not have any pagination, so it always returns a single dataclass that needs to be normalized differently to reflect on the dataframe.
 
     normalized_results = ProcessLineageNormalizer(
         raw_results=results,
@@ -72,16 +76,34 @@ def process_lineage(
 def process_children(
         region: Annotated[Optional[str], typer.Option(help="Taegis region")] = None,
         tenant_id: Annotated[Optional[str], typer.Option(help="Taegis tenant id")] = None,
-        host_id: Annotated[str, typer.Argument(help="Taegis host id")] = None,
-        process_correlation_id: Annotated[str, typer.Argument(help="Taegis Event process correlation id")] = None,
-        resource_id: Annotated[str, typer.Argument(help="Taegis Event resource ID")] = None,
+        host_id: Annotated[str, typer.Option(help="Taegis host id")] = None,
+        process_correlation_id: Annotated[str, typer.Option(help="Taegis Event process correlation id")] = None,
+        resource_id: Annotated[str, typer.Option(help="Taegis Event resource ID")] = None,
 ):
     """Get process children for a given region & tenant, based on the resource_id, host_id, and process_correlation_id."""
     service = get_service(environment=region, tenant_id=tenant_id)
-    results = service.process_trees.query.process_children(host_id=host_id, process_correlation_id=process_correlation_id, tenant_id=tenant_id, resource_id=resource_id)
+    all_results = []
+    next_token = None
 
-    normalized_results = TaegisResult(
-        raw_results=results,
+    # Process children has pagination, so we need to loop through all next_token calls until there are no more results.
+    while True:
+        results = service.process_trees.query.process_children(
+            host_id=host_id,
+            process_correlation_id=process_correlation_id,
+            tenant_id=tenant_id,
+            resource_id=resource_id,
+            next_token=next_token,
+        )
+        
+        if hasattr(results, "process_list") and results.process_list:
+            all_results.extend(results.process_list)
+        
+        next_token = getattr(results, "next_token", None)
+        if not next_token:
+            break
+
+    normalized_results = TaegisResults(
+        raw_results=all_results,
         service="process_children",
         tenant_id=service.tenant_id,
         region=service.environment,
@@ -96,9 +118,9 @@ def process_children(
 def process_parent(
         region: Annotated[Optional[str], typer.Option(help="Taegis region")] = None,
         tenant_id: Annotated[Optional[str], typer.Option(help="Taegis tenant id")] = None,
-        host_id: Annotated[str, typer.Argument(help="Taegis host id")] = None,
-        parent_pcid: Annotated[str, typer.Argument(help="Taegis Event process correlation id")] = None,
-        resource_id: Annotated[str, typer.Argument(help="Taegis Event resource ID")] = None,
+        host_id: Annotated[str, typer.Option(help="Taegis host id")] = None,
+        parent_pcid: Annotated[str, typer.Option(help="Taegis Event process correlation id")] = None,
+        resource_id: Annotated[str, typer.Option(help="Taegis Event resource ID")] = None,
 ):
     """Gets the processes' parent based on the parent_correlation_id for a given region & tenant, based on the resource_id, host_id, and parent_process_correlation_id."""
     service = get_service(environment=region, tenant_id=tenant_id)

--- a/taegis_magic/commands/process_trees.py
+++ b/taegis_magic/commands/process_trees.py
@@ -8,10 +8,7 @@ from typing_extensions import Annotated
 from dataclasses import asdict, dataclass, field
 from taegis_magic.core.log import tracing
 from taegis_magic.core.normalizer import TaegisResult
-from taegis_magic.core.service import get_service
-from taegis_magic.commands.events import search
-
-from taegis_magic.core.utils import to_dataframe
+from taegis_magic.core.service import get_service                                               
 
 app = typer.Typer(help="Taegis Subjects Commands.")
 
@@ -75,9 +72,9 @@ def process_lineage(
 def process_children(
         region: Annotated[Optional[str], typer.Option(help="Taegis region")] = None,
         tenant_id: Annotated[Optional[str], typer.Option(help="Taegis tenant id")] = None,
-        host_id: Annotated[Optional[str], typer.Option(help="Taegis host id")] = None,
-        process_correlation_id: Annotated[Optional[str], typer.Option(help="Taegis Event process correlation id")] = None,
-        resource_id: Annotated[Optional[str], typer.Option(help="Taegis Event resource ID")] = None,
+        host_id: Annotated[str, typer.Argument(help="Taegis host id")] = None,
+        process_correlation_id: Annotated[str, typer.Argument(help="Taegis Event process correlation id")] = None,
+        resource_id: Annotated[str, typer.Argument(help="Taegis Event resource ID")] = None,
 ):
     """Get process children for a given region & tenant, based on the resource_id, host_id, and process_correlation_id."""
     service = get_service(environment=region, tenant_id=tenant_id)
@@ -99,9 +96,9 @@ def process_children(
 def process_parent(
         region: Annotated[Optional[str], typer.Option(help="Taegis region")] = None,
         tenant_id: Annotated[Optional[str], typer.Option(help="Taegis tenant id")] = None,
-        host_id: Annotated[Optional[str], typer.Option(help="Taegis host id")] = None,
-        parent_pcid: Annotated[Optional[str], typer.Option(help="Taegis Event process correlation id")] = None,
-        resource_id: Annotated[Optional[str], typer.Option(help="Taegis Event resource ID")] = None,
+        host_id: Annotated[str, typer.Argument(help="Taegis host id")] = None,
+        parent_pcid: Annotated[str, typer.Argument(help="Taegis Event process correlation id")] = None,
+        resource_id: Annotated[str, typer.Argument(help="Taegis Event resource ID")] = None,
 ):
     """Gets the processes' parent based on the parent_correlation_id for a given region & tenant, based on the resource_id, host_id, and parent_process_correlation_id."""
     service = get_service(environment=region, tenant_id=tenant_id)

--- a/taegis_magic/pandas/process_trees.py
+++ b/taegis_magic/pandas/process_trees.py
@@ -1,0 +1,70 @@
+"""Pandas functions for Proccess Lineage Event Dataframes (process only)"""
+
+import logging
+import pandas as pd
+from typing import List, Optional
+from dataclasses import asdict
+from taegis_magic.commands.process_trees import process_lineage
+
+
+log = logging.getLogger(__name__)
+
+def lookup_lineage(
+    df: pd.DataFrame, region: Optional[str] = None, tenant_id: Optional[str] = None
+) -> pd.DataFrame:
+    """
+    For each row in the DataFrame, fetch process lineage using process_correlation_id, host_id, tenant_id, and resource_id.
+    Adds a new column 'process_lineage' with the results.
+    
+    Parameters
+    ----------
+    df : pd.DataFrame
+        A pandas DataFrame that contains Taegis process events with process_correlation_id, host_id, tenant_id, and resource_id.
+    tenant_id: Optional[str]
+        Taegis SDK Tenant ID that the asset lookup is for.  Defaults to None.
+    region : Optional[str]
+        Taegis SDK Region/Environment that the asset lookup is for.  Defaults to US1.
+
+    Returns
+    -------
+    pd.DataFrame
+        Returns a pandas DataFrame with additional asset information columns.
+
+    Raises
+    ------
+    ValueError
+        If the event is not a process event, or if process_correlation_id, host_id, and resource_id does not have columns in the dataframe a value error will be raised.
+    """
+
+    df = df.copy()
+    if df.empty:
+        return df
+
+    required_cols = ["host_id", "process_correlation_id", "resource_id"]
+    if not all(x in df.columns for x in required_cols):
+        raise ValueError("DataFrame must contain host_id, process_correlation_id, and resource_id columns for lineage lookup.")
+
+    def get_lineage(row):
+        if pd.isna(row.get("host_id")) or pd.isna(row.get("process_correlation_id")) or pd.isna(row.get("resource_id")):
+            return []
+        
+        else: 
+            result = process_lineage(
+                region=region,
+                tenant_id=tenant_id,
+                host_id=row.get("host_id"),
+                process_correlation_id=row.get("process_correlation_id"),
+                resource_id=row.get("resource_id"),
+            )
+
+        # Check if there are results in the process_lineage call. If not, return empty.
+        if hasattr(result, "results") and result.results is not None:
+            return result.results
+        else:
+            return []
+
+    df["process_lineage"] = df.apply(get_lineage, axis=1)
+    df = df.explode("process_lineage").reset_index(drop=True)
+    df["process_lineage"] = df["process_lineage"].apply(lambda x: {} if pd.isnull(x) else x)
+    df["process_lineage_index"] = df["process_lineage"].apply(lambda x: int(x.get("lineage_index", None)) if x.get("lineage_index", None) is not None else None)
+    return df

--- a/taegis_magic/pandas/process_trees.py
+++ b/taegis_magic/pandas/process_trees.py
@@ -4,7 +4,7 @@ import logging
 import pandas as pd
 from typing import List, Optional
 from dataclasses import asdict
-from taegis_magic.commands.process_trees import process_lineage
+from taegis_magic.commands.process_trees import process_lineage, process_children
 
 
 log = logging.getLogger(__name__)
@@ -34,11 +34,13 @@ def lookup_lineage(
     ------
     ValueError
         If the event is not a process event, or if process_correlation_id, host_id, and resource_id does not have columns in the dataframe a value error will be raised.
+        If there the dataframe does not contain a valid tenant identifier.
     """
 
     df = df.copy()
     if df.empty:
         return df
+    
 
     required_cols = ["host_id", "process_correlation_id", "resource_id"]
     if not all(x in df.columns for x in required_cols):
@@ -63,8 +65,68 @@ def lookup_lineage(
         else:
             return []
 
-    df["process_lineage"] = df.apply(get_lineage, axis=1)
-    df = df.explode("process_lineage").reset_index(drop=True)
-    df["process_lineage"] = df["process_lineage"].apply(lambda x: {} if pd.isnull(x) else x)
-    df["process_lineage_index"] = df["process_lineage"].apply(lambda x: int(x.get("lineage_index", None)) if x.get("lineage_index", None) is not None else None)
+    df["process_info.process_lineage"] = df.apply(get_lineage, axis=1)
+    df = df.explode("process_info.process_lineage").reset_index(drop=True)
+    df["process_info.process_lineage"] = df["process_info.process_lineage"].apply(lambda x: {} if pd.isnull(x) else x)
+    df["process_info.process_lineage.index"] = df["process_info.process_lineage"].apply(lambda x: int(x.get("lineage_index", None)) if x.get("lineage_index", None) is not None else None)
+    return df
+
+def lookup_children(
+    df: pd.DataFrame, region: Optional[str] = None, tenant_id: Optional[str] = None
+) -> pd.DataFrame:
+    """
+    For each row in the DataFrame, fetch their children processes using process_correlation_id, host_id, tenant_id, and resource_id.
+    Adds a new column 'process_children' with the results.
+    
+    Parameters
+    ----------
+    df : pd.DataFrame
+        A pandas DataFrame that contains Taegis process events with process_correlation_id, host_id, tenant_id, and resource_id.
+    tenant_id: Optional[str]
+        Taegis SDK Tenant ID that the asset lookup is for.  Defaults to None.
+    region : Optional[str]
+        Taegis SDK Region/Environment that the asset lookup is for.  Defaults to US1.
+
+    Returns
+    -------
+    pd.DataFrame
+        Returns a pandas DataFrame with additional asset information columns.
+
+    Raises
+    ------
+    ValueError
+        If the event is not a process event, or if process_correlation_id, host_id, and resource_id does not have columns in the dataframe a value error will be raised.
+    """
+
+    df = df.copy()
+    if df.empty:
+        return df
+
+    required_cols = ["host_id", "process_correlation_id", "resource_id"]
+    if not all(x in df.columns for x in required_cols):
+        raise ValueError("DataFrame must contain host_id, process_correlation_id, and resource_id columns for lineage lookup.")
+    
+
+    def get_children(row):
+        if pd.isna(row.get("host_id")) or pd.isna(row.get("process_correlation_id")) or pd.isna(row.get("resource_id")):
+            return []
+        
+        else: 
+            result = process_children(
+                region=region,
+                tenant_id=tenant_id,
+                host_id=row.get("host_id"),
+                process_correlation_id=row.get("process_correlation_id"),
+                resource_id=row.get("resource_id"),
+            )
+
+        # Check if there are results in the process_children call. If not, return empty.
+        if hasattr(result, "results") and result.results is not None:
+            return result.results
+        else:
+            return []
+        
+    df["process_info.process_children"] = df.apply(get_children, axis=1)
+    df = df.explode("process_info.process_children").reset_index(drop=True)
+    df["process_info.process_children"] = df["process_info.process_children"].apply(lambda x: {} if pd.isnull(x) else x)
     return df


### PR DESCRIPTION
**DESCRIPTION:** Creating this PR to add CLI and Magic functions for Process Trees. This adds the typer command process-trees with subfunctions for: process-lineage, process-children, and process-parent. 

Pipe functions were also created under pandas folder to run a lookup_lineage and lookup_children referencing this command if a dataframe has applicable columns.

This PR closes issue https://github.com/secureworks/taegis-magic/issues/68 as process trees haven't been implemented on Taegis Magic.

**TESTING:** To test, run CLI commands 
`taegis process-trees process-children --resource-id "" --process-correlation-id "" --tenant-id "" --region "" --host-id ""`
`taegis process-trees process-lineage --resource-id "" --process-correlation-id "" --tenant-id "" --region "" --host-id ""`
`taegis process-trees process-parent --resource-id "" --parent-pcid "" --tenant-id "" --region "" --host-id ""`


For pipe commands, open Jupyter Notebook and run the following:
`%load_ext taegis_magic`

`%%taegis events search --region delta --tenant 149369 --assign check_df`
`from filemod, generic, process | head 1`

`from taegis_magic.pandas.process_trees import lookup_lineage, lookup_children`
`check_children = check_df.pipe(lookup_children, region = "", tenant_id = "")`
`check_lineage = check_df.pipe(lookup_lineage, region = "delta", tenant_id = "149369")`
