### PR TITLE
CX-159015: adding macros support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.github/copilot-instructions.md
+.vscode/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dependencies = [
     "requests",
     "ipynbname",
     "panel",
-    "tabulator",  
+    "tabulator",
+    "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -61,3 +62,9 @@ path = "taegis_magic/_version.py"
 
 [tool.hatch.build.targets.sdist]
 include = ["/taegis_magic"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["taegis_magic"]
+
+[tool.hatch.build]
+artifacts = ["taegis_magic/resources/*.yaml"]

--- a/taegis_magic/commands/alerts.py
+++ b/taegis_magic/commands/alerts.py
@@ -10,7 +10,12 @@ from dataclasses_json import config, dataclass_json
 from taegis_magic.commands.configure import QUERIES_SECTION
 from taegis_magic.commands.utils.investigations import insert_search_query
 from taegis_magic.core.log import tracing
-from taegis_magic.core.normalizer import TaegisResults, TaegisResultsNormalizer
+from taegis_magic.core.macros import resolve_tenants
+from taegis_magic.core.normalizer import (
+    TaegisResults,
+    TaegisResultsNormalizer,
+    merge_normalizer_results,
+)
 from taegis_magic.core.service import get_service
 from typing_extensions import Annotated
 
@@ -256,28 +261,15 @@ def alerts_service_poll_with_events(
     raise GraphQLNoRowsInResultSetError("for custom query alertsServicePoll")
 
 
-@app.command()
-@tracing
-def search(
-    cell: Optional[str] = None,
-    region: Optional[str] = None,
-    tenant: Optional[str] = None,
-    limit: int = 10000,
-    graphql_output: Optional[str] = None,
-    track: Annotated[bool, typer.Option()] = CONFIG[QUERIES_SECTION].getboolean(
-        "track", fallback=False
-    ),
-    database: Annotated[str, typer.Option()] = ":memory:",
-) -> Optional[AlertsResultsNormalizer]:
-    """
-    Search Taegis Alerts service.
-    """
-    service = get_service(environment=region, tenant_id=tenant)
-    if not cell:
-        cell = ""
-
-    if "aggregate" in cell:
-        limit = 1
+def _search_single_tenant(
+    cell: str,
+    region: Optional[str],
+    tenant_id: Optional[str],
+    limit: int,
+    graphql_output: Optional[str],
+) -> AlertsResultsNormalizer:
+    """Execute an alerts search against a single tenant."""
+    service = get_service(environment=region, tenant_id=tenant_id)
 
     with service(output=graphql_output):
         result = alerts_service_search_with_events(
@@ -326,7 +318,7 @@ def search(
                 ):
                     break
 
-    results = AlertsResultsNormalizer(
+    return AlertsResultsNormalizer(
         raw_results=poll_responses,
         service="alerts",
         tenant_id=service.tenant_id,
@@ -340,6 +332,43 @@ def search(
             "graphql_output": graphql_output,
         },
     )
+
+
+@app.command()
+@tracing
+def search(
+    cell: Optional[str] = None,
+    region: Optional[str] = None,
+    tenant: Optional[str] = None,
+    limit: int = 10000,
+    graphql_output: Optional[str] = None,
+    track: Annotated[bool, typer.Option()] = CONFIG[QUERIES_SECTION].getboolean(
+        "track", fallback=False
+    ),
+    database: Annotated[str, typer.Option()] = ":memory:",
+) -> Optional[AlertsResultsNormalizer]:
+    """
+    Search Taegis Alerts service.
+
+    Supports @macro syntax in --tenant to search across multiple tenants.
+    """
+    if not cell:
+        cell = ""
+
+    if "aggregate" in cell:
+        limit = 1
+
+    tenant_ids = resolve_tenants(tenant, region)
+
+    all_results = [
+        _search_single_tenant(cell, region, tid, limit, graphql_output)
+        for tid in tenant_ids
+    ]
+
+    if len(all_results) == 1:
+        results = all_results[0]
+    else:
+        results = merge_normalizer_results(all_results)
 
     if track:
         insert_search_query(database, results)

--- a/taegis_magic/commands/configure.py
+++ b/taegis_magic/commands/configure.py
@@ -27,10 +27,12 @@ middlewares = typer.Typer(help="Configure HTTP Middleware modules.")
 middlewares_retry = typer.Typer(help="Configure HTTP Retry middleware.")
 
 template = typer.Typer(help="Configure Template options.")
+macros = typer.Typer(help="Configure Tenant Macro Commands.")
 
 middlewares.add_typer(middlewares_retry, name="retry")
 
 app.add_typer(auth, name="auth")
+app.add_typer(macros, name="macros")
 app.add_typer(middlewares, name="middlewares")
 app.add_typer(regions, name="regions")
 app.add_typer(template, name="template")
@@ -39,6 +41,7 @@ app.add_typer(configure_logging, name="logging")
 
 
 AUTH_SECTION = "magics.auth"
+MACROS_SECTION = "magics.macros"
 REGIONS_SECTION = "magics.regions"
 QUERIES_SECTION = "magics.queries"
 LOGGING_SECTION = "magics.logging"
@@ -120,6 +123,9 @@ def set_defaults():  # pragma: no cover
 
     if not config.has_section(MIDDLEWARES_SECTION):
         config.add_section(MIDDLEWARES_SECTION)
+
+    if not config.has_section(MACROS_SECTION):
+        config.add_section(MACROS_SECTION)
 
     if not config.has_section(RETRY_SECTION):
         config.add_section(RETRY_SECTION)
@@ -528,6 +534,82 @@ def middlewares_retry_list():
                 value=value,
             )
             for name, value in config[RETRY_SECTION].items()
+        ],
+    )
+    return results
+
+
+@macros.command(name="path")
+@tracing
+def macros_path(
+    path: Annotated[
+        Path,
+        typer.Argument(
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            writable=False,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+):
+    """Set a custom YAML resource path for tenant macros."""
+    write_to_config(
+        MACROS_SECTION,
+        "resource_path",
+        str(path),
+    )
+
+    results = ConfigurationNormalizer(
+        service="configure",
+        tenant_id="None",
+        region="None",
+        raw_results=[dict(resource_path=str(path))],
+    )
+    return results
+
+
+@macros.command(name="reset")
+@tracing
+def macros_reset():
+    """Reset tenant macros to the bundled default resource."""
+    from taegis_magic.core.macros import DEFAULT_MACROS_PATH
+
+    config = get_config()
+    config.remove_option(MACROS_SECTION, "resource_path")
+    write_config(config)
+
+    results = ConfigurationNormalizer(
+        service="configure",
+        tenant_id="None",
+        region="None",
+        raw_results=[dict(resource_path=str(DEFAULT_MACROS_PATH), status="reset")],
+    )
+    return results
+
+
+@macros.command(name="list")
+@tracing
+def macros_list():
+    """List available tenant macros and the current resource path."""
+    from taegis_magic.core.macros import get_macros_config_path, load_macros
+
+    macros_path = get_macros_config_path()
+    macro_defs = load_macros(macros_path)
+
+    results = ConfigurationNormalizer(
+        service="configure",
+        tenant_id="None",
+        region="None",
+        raw_results=[
+            dict(
+                resource_path=str(macros_path),
+                macros=[
+                    dict(name=name, definition=definition)
+                    for name, definition in macro_defs.items()
+                ],
+            )
         ],
     )
     return results

--- a/taegis_magic/commands/configure.py
+++ b/taegis_magic/commands/configure.py
@@ -574,7 +574,7 @@ def macros_path(
 @tracing
 def macros_reset():
     """Reset tenant macros to the bundled default resource."""
-    from taegis_magic.core.macros import DEFAULT_MACROS_PATH
+    from taegis_magic.core.macros import DEFAULT_MACROS_RESOURCE
 
     config = get_config()
     config.remove_option(MACROS_SECTION, "resource_path")
@@ -584,7 +584,7 @@ def macros_reset():
         service="configure",
         tenant_id="None",
         region="None",
-        raw_results=[dict(resource_path=str(DEFAULT_MACROS_PATH), status="reset")],
+        raw_results=[dict(resource_path=str(DEFAULT_MACROS_RESOURCE), status="reset")],
     )
     return results
 
@@ -593,10 +593,15 @@ def macros_reset():
 @tracing
 def macros_list():
     """List available tenant macros and the current resource path."""
-    from taegis_magic.core.macros import get_macros_config_path, load_macros
+    from taegis_magic.core.macros import (
+        DEFAULT_MACROS_RESOURCE,
+        _get_custom_macros_path,
+        load_macros,
+    )
 
-    macros_path = get_macros_config_path()
-    macro_defs = load_macros(macros_path)
+    custom_path = _get_custom_macros_path()
+    source = str(custom_path) if custom_path else str(DEFAULT_MACROS_RESOURCE)
+    macro_defs = load_macros(custom_path)
 
     results = ConfigurationNormalizer(
         service="configure",
@@ -604,7 +609,7 @@ def macros_list():
         region="None",
         raw_results=[
             dict(
-                resource_path=str(macros_path),
+                resource_path=source,
                 macros=[
                     dict(name=name, definition=definition)
                     for name, definition in macro_defs.items()

--- a/taegis_magic/core/macros.py
+++ b/taegis_magic/core/macros.py
@@ -5,6 +5,7 @@ using the tenantsv4 API, with macro definitions stored in a YAML resource.
 """
 
 import logging
+from importlib.resources import files
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -21,15 +22,11 @@ from taegis_sdk_python.services.tenants4.types import (
 log = logging.getLogger(__name__)
 
 MACROS_SECTION = "magics.macros"
-DEFAULT_MACROS_PATH = Path(__file__).parent.parent / "resources" / "default_macros.yaml"
+DEFAULT_MACROS_RESOURCE = files("taegis_magic.resources").joinpath("default_macros.yaml")
 
 
-def get_macros_config_path() -> Path:
-    """Return the path to the macros YAML resource.
-
-    Checks the SDK config for a custom path override, falling
-    back to the bundled default.
-    """
+def _get_custom_macros_path() -> Optional[Path]:
+    """Return a custom macros path from config, if set and valid."""
     config = get_config()
 
     if config.has_section(MACROS_SECTION) and config.has_option(
@@ -43,7 +40,7 @@ def get_macros_config_path() -> Path:
             custom_path,
         )
 
-    return DEFAULT_MACROS_PATH
+    return None
 
 
 def load_macros(path: Optional[Path] = None) -> Dict[str, Any]:
@@ -52,23 +49,30 @@ def load_macros(path: Optional[Path] = None) -> Dict[str, Any]:
     Parameters
     ----------
     path
-        Path to the YAML file.  Uses the configured path when ``None``.
+        Path to a custom YAML file.  When ``None``, checks the SDK
+        config for a custom path, then falls back to the bundled
+        default resource via ``importlib.resources``.
 
     Returns
     -------
     dict
         Mapping of macro name to its definition dict.
     """
-    if path is None:
-        path = get_macros_config_path()
+    if path is not None:
+        if not path.exists():
+            log.warning("Macros file %s not found", path)
+            return {}
+        with open(path, "r") as fh:
+            data = yaml.safe_load(fh) or {}
+        return data.get("macros", {})
 
-    if not path.exists():
-        log.warning("Macros file %s not found", path)
-        return {}
+    custom_path = _get_custom_macros_path()
+    if custom_path is not None:
+        with open(custom_path, "r") as fh:
+            data = yaml.safe_load(fh) or {}
+        return data.get("macros", {})
 
-    with open(path, "r") as fh:
-        data = yaml.safe_load(fh) or {}
-
+    data = yaml.safe_load(DEFAULT_MACROS_RESOURCE.read_text()) or {}
     return data.get("macros", {})
 
 
@@ -84,35 +88,35 @@ def _build_tenants_queries(macro_def: Dict[str, Any]) -> List[TenantsQuery]:
     """
     base_kwargs: Dict[str, Any] = {}
 
-    if names := macro_def.get("names"):
-        base_kwargs["names"] = names
+    # if names := macro_def.get("names"):
+    #     base_kwargs["names"] = names
 
-    if ids := macro_def.get("ids"):
-        base_kwargs["ids"] = ids
+    # if ids := macro_def.get("ids"):
+    #     base_kwargs["ids"] = ids
 
-    if partners := macro_def.get("partners"):
-        base_kwargs["partners"] = partners
+    # if partners := macro_def.get("partners"):
+    #     base_kwargs["partners"] = partners
 
-    if organizations := macro_def.get("organizations"):
-        base_kwargs["organizations"] = organizations
+    # if organizations := macro_def.get("organizations"):
+    #     base_kwargs["organizations"] = organizations
 
-    if hierarchies := macro_def.get("hierarchies"):
-        base_kwargs["hierarchies"] = hierarchies
+    # if hierarchies := macro_def.get("hierarchies"):
+    #     base_kwargs["hierarchies"] = hierarchies
 
-    if mdr_providers := macro_def.get("mdr_providers"):
-        base_kwargs["mdr_providers"] = mdr_providers
+    # if mdr_providers := macro_def.get("mdr_providers"):
+    #     base_kwargs["mdr_providers"] = mdr_providers
 
-    if labels := macro_def.get("labels"):
-        base_kwargs["labels_match"] = [
-            TenantLabelMatcher(
-                name=label.get("name"),
-                value=label.get("value"),
-            )
-            for label in labels
-        ]
+    # if labels := macro_def.get("labels"):
+    #     base_kwargs["labels_match"] = [
+    #         TenantLabelMatcher(
+    #             name=label.get("name"),
+    #             value=label.get("value"),
+    #         )
+    #         for label in labels
+    #     ]
 
-    if (enabled := macro_def.get("enabled")) is not None:
-        base_kwargs["enabled"] = enabled
+    # if (enabled := macro_def.get("enabled")) is not None:
+    #     base_kwargs["enabled"] = enabled
 
     services = macro_def.get("services")
     if not services:

--- a/taegis_magic/core/macros.py
+++ b/taegis_magic/core/macros.py
@@ -1,0 +1,227 @@
+"""Taegis Magic Tenant Macros.
+
+Resolve @macro syntax in the --tenant flag to a list of tenant IDs
+using the tenantsv4 API, with macro definitions stored in a YAML resource.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from taegis_magic.core.service import get_service
+from taegis_sdk_python.config import get_config
+from taegis_sdk_python.services.tenants4.types import (
+    SubscriptionMatcher,
+    TenantsQuery,
+    TenantLabelMatcher,
+)
+
+log = logging.getLogger(__name__)
+
+MACROS_SECTION = "magics.macros"
+DEFAULT_MACROS_PATH = Path(__file__).parent.parent / "resources" / "default_macros.yaml"
+
+
+def get_macros_config_path() -> Path:
+    """Return the path to the macros YAML resource.
+
+    Checks the SDK config for a custom path override, falling
+    back to the bundled default.
+    """
+    config = get_config()
+
+    if config.has_section(MACROS_SECTION) and config.has_option(
+        MACROS_SECTION, "resource_path"
+    ):
+        custom_path = Path(config.get(MACROS_SECTION, "resource_path"))
+        if custom_path.exists():
+            return custom_path
+        log.warning(
+            "Custom macros path %s does not exist, falling back to default",
+            custom_path,
+        )
+
+    return DEFAULT_MACROS_PATH
+
+
+def load_macros(path: Optional[Path] = None) -> Dict[str, Any]:
+    """Load macro definitions from a YAML file.
+
+    Parameters
+    ----------
+    path
+        Path to the YAML file.  Uses the configured path when ``None``.
+
+    Returns
+    -------
+    dict
+        Mapping of macro name to its definition dict.
+    """
+    if path is None:
+        path = get_macros_config_path()
+
+    if not path.exists():
+        log.warning("Macros file %s not found", path)
+        return {}
+
+    with open(path, "r") as fh:
+        data = yaml.safe_load(fh) or {}
+
+    return data.get("macros", {})
+
+
+def _build_tenants_queries(macro_def: Dict[str, Any]) -> List[TenantsQuery]:
+    """Translate a user-friendly macro definition into TenantsQuery objects.
+
+    The YAML format uses simple keys like ``services`` and ``labels``
+    that are translated into the tenantsv4 ``TenantsQuery`` input type.
+
+    Because tenantsv4 treats ``subscriptionsMatch`` as AND (all must
+    match), multiple services are split into separate queries that are
+    executed independently and their results unioned (OR semantics).
+    """
+    base_kwargs: Dict[str, Any] = {}
+
+    if names := macro_def.get("names"):
+        base_kwargs["names"] = names
+
+    if ids := macro_def.get("ids"):
+        base_kwargs["ids"] = ids
+
+    if partners := macro_def.get("partners"):
+        base_kwargs["partners"] = partners
+
+    if organizations := macro_def.get("organizations"):
+        base_kwargs["organizations"] = organizations
+
+    if hierarchies := macro_def.get("hierarchies"):
+        base_kwargs["hierarchies"] = hierarchies
+
+    if mdr_providers := macro_def.get("mdr_providers"):
+        base_kwargs["mdr_providers"] = mdr_providers
+
+    if labels := macro_def.get("labels"):
+        base_kwargs["labels_match"] = [
+            TenantLabelMatcher(
+                name=label.get("name"),
+                value=label.get("value"),
+            )
+            for label in labels
+        ]
+
+    if (enabled := macro_def.get("enabled")) is not None:
+        base_kwargs["enabled"] = enabled
+
+    services = macro_def.get("services")
+    if not services:
+        return [TenantsQuery(**base_kwargs)]
+
+    # One query per service → union results (OR semantics)
+    return [
+        TenantsQuery(
+            subscriptions_match=[SubscriptionMatcher(name=svc)],
+            **base_kwargs,
+        )
+        for svc in services
+    ]
+
+
+def _fetch_tenant_ids_single(
+    service,
+    query: TenantsQuery,
+) -> List[str]:
+    """Execute a single tenantsv4 query with pagination.
+
+    TenantsQuery is a frozen dataclass, so pagination creates
+    a new query instance with the updated cursor on each page.
+    """
+    from dataclasses import replace
+
+    tenant_ids: List[str] = []
+
+    result = service.tenants4.query.tenants(tenants_query=query)
+    tenant_ids.extend(t.id for t in (result.tenants or []))
+
+    while result.has_more:
+        query = replace(query, after_cursor=result.cursor_pos)
+        result = service.tenants4.query.tenants(tenants_query=query)
+        tenant_ids.extend(t.id for t in (result.tenants or []))
+
+    return tenant_ids
+
+
+def _fetch_tenant_ids(
+    queries: List[TenantsQuery],
+    region: Optional[str] = None,
+) -> List[str]:
+    """Execute tenantsv4 queries and return all matching tenant IDs.
+
+    Multiple queries are executed independently and results are
+    unioned (deduplicated) to achieve OR semantics across services.
+    """
+    service = get_service(environment=region)
+    seen: set = set()
+    tenant_ids: List[str] = []
+
+    for query in queries:
+        for tid in _fetch_tenant_ids_single(service, query):
+            if tid not in seen:
+                seen.add(tid)
+                tenant_ids.append(tid)
+
+    log.info("Macro resolved to %d unique tenant(s) from %d query(ies)",
+             len(tenant_ids), len(queries))
+
+    return tenant_ids
+
+
+def resolve_tenants(
+    tenant: Optional[str],
+    region: Optional[str] = None,
+) -> List[Optional[str]]:
+    """Resolve a tenant value, expanding macros if present.
+
+    Parameters
+    ----------
+    tenant
+        A tenant ID string, or a ``@macro`` reference.
+        When ``None``, returns ``[None]`` (passthrough to default behaviour).
+    region
+        Taegis region for the tenantsv4 API call.
+
+    Returns
+    -------
+    list
+        A list of tenant ID strings.  For non-macro values this
+        will be a single-element list.
+
+    Raises
+    ------
+    ValueError
+        If the macro name is not found in the YAML resource.
+    """
+    if tenant is None or not tenant.startswith("@"):
+        return [tenant]
+
+    macro_name = tenant[1:]
+    log.info("Resolving tenant macro: @%s", macro_name)
+
+    macros = load_macros()
+
+    if macro_name not in macros:
+        available = ", ".join(f"@{m}" for m in macros) or "(none defined)"
+        raise ValueError(
+            f"Unknown tenant macro '@{macro_name}'. "
+            f"Available macros: {available}"
+        )
+
+    macro_def = macros[macro_name]
+    queries = _build_tenants_queries(macro_def)
+    tenant_ids = _fetch_tenant_ids(queries, region=region)
+
+    if not tenant_ids:
+        log.warning("Macro @%s resolved to zero tenants", macro_name)
+
+    return tenant_ids

--- a/taegis_magic/core/macros.py
+++ b/taegis_magic/core/macros.py
@@ -88,35 +88,6 @@ def _build_tenants_queries(macro_def: Dict[str, Any]) -> List[TenantsQuery]:
     """
     base_kwargs: Dict[str, Any] = {}
 
-    # if names := macro_def.get("names"):
-    #     base_kwargs["names"] = names
-
-    # if ids := macro_def.get("ids"):
-    #     base_kwargs["ids"] = ids
-
-    # if partners := macro_def.get("partners"):
-    #     base_kwargs["partners"] = partners
-
-    # if organizations := macro_def.get("organizations"):
-    #     base_kwargs["organizations"] = organizations
-
-    # if hierarchies := macro_def.get("hierarchies"):
-    #     base_kwargs["hierarchies"] = hierarchies
-
-    # if mdr_providers := macro_def.get("mdr_providers"):
-    #     base_kwargs["mdr_providers"] = mdr_providers
-
-    # if labels := macro_def.get("labels"):
-    #     base_kwargs["labels_match"] = [
-    #         TenantLabelMatcher(
-    #             name=label.get("name"),
-    #             value=label.get("value"),
-    #         )
-    #         for label in labels
-    #     ]
-
-    # if (enabled := macro_def.get("enabled")) is not None:
-    #     base_kwargs["enabled"] = enabled
 
     services = macro_def.get("services")
     if not services:
@@ -166,19 +137,15 @@ def _fetch_tenant_ids(
     unioned (deduplicated) to achieve OR semantics across services.
     """
     service = get_service(environment=region)
-    seen: set = set()
-    tenant_ids: List[str] = []
+    tenant_ids: set = set()
 
     for query in queries:
-        for tid in _fetch_tenant_ids_single(service, query):
-            if tid not in seen:
-                seen.add(tid)
-                tenant_ids.append(tid)
+        tenant_ids.update(_fetch_tenant_ids_single(service, query))
 
     log.info("Macro resolved to %d unique tenant(s) from %d query(ies)",
              len(tenant_ids), len(queries))
 
-    return tenant_ids
+    return list(tenant_ids)
 
 
 def resolve_tenants(

--- a/taegis_magic/core/normalizer.py
+++ b/taegis_magic/core/normalizer.py
@@ -1,5 +1,6 @@
 """Taegis Base Normalizer."""
 
+import logging
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Union
 
@@ -90,6 +91,67 @@ class TaegisResults(TaegisResultsNormalizer):
     @property
     def results(self):
         return [asdict(r) for r in self.raw_results]
+
+
+log = logging.getLogger(__name__)
+
+
+def merge_normalizer_results(
+    results: List[TaegisResultsNormalizer],
+) -> TaegisResultsNormalizer:
+    """Merge multiple normalizer results from a multi-tenant macro execution.
+
+    Each result's individual records are tagged with ``_macro_tenant_id``
+    so the originating tenant is preserved after merging.
+
+    Parameters
+    ----------
+    results
+        Normalizer instances to merge, one per tenant execution.
+
+    Returns
+    -------
+    TaegisResultsNormalizer
+        A single normalizer with all results combined.
+    """
+    if not results:
+        return TaegisResultsNormalizer(
+            service="unknown",
+            tenant_id="None",
+            region="None",
+        )
+
+    if len(results) == 1:
+        return results[0]
+
+    merged_raw: List[Dict[str, Any]] = []
+    tenant_ids: List[str] = []
+
+    for normalizer in results:
+        tid = normalizer.tenant_id
+        tenant_ids.append(tid)
+        for record in normalizer.results:
+            tagged = dict(record)
+            tagged["_macro_tenant_id"] = tid
+            merged_raw.append(tagged)
+
+    first = results[0]
+
+    merged = TaegisResultsNormalizer(
+        service=first.service,
+        tenant_id=", ".join(tenant_ids),
+        region=first.region,
+        raw_results=merged_raw,
+        arguments=first.arguments,
+    )
+
+    log.info(
+        "Merged results from %d tenants (%d total records)",
+        len(results),
+        len(merged_raw),
+    )
+
+    return merged
 
 
 @dataclass_json

--- a/taegis_magic/resources/__init__.py
+++ b/taegis_magic/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Taegis Magic bundled resources."""

--- a/taegis_magic/resources/default_macros.yaml
+++ b/taegis_magic/resources/default_macros.yaml
@@ -1,0 +1,29 @@
+# Taegis Magic Tenant Macros
+#
+# Each macro defines a shorthand that expands to a tenantsv4 tenant query.
+# Use macros in the --tenant flag with an @ prefix, e.g.: --tenant @mdr
+#
+# Supported fields per macro:
+#   services       - List of tenant service/subscription names to match
+#                    (supports * wildcard, e.g. "*MDR*")
+#   names          - List of tenant name patterns (supports * wildcard)
+#   ids            - List of specific tenant IDs
+#   partners       - List of partner tenant IDs to search under
+#   organizations  - List of organization tenant IDs to search under
+#   hierarchies    - List of hierarchy IDs (partners, orgs, or customers)
+#   mdr_providers  - List of MDR provider IDs to filter by
+#   labels         - List of {name, value} label matchers (supports * wildcard)
+#   enabled        - Boolean, filter to tenants enabled in the current region
+#
+# Note: Multiple services use OR logic (tenants matching ANY service).
+# The SubscriptionMatcher "name" field supports * as wildcard.
+
+macros:
+  mdr:
+    services:
+      - "*ManagedXDR Essentials*"
+      - "*MDR*"
+      - "*Dell SafeGuard*"
+      - "*MXDR POC*"
+      - "*EIR Monitoring*"
+      - "*iSensor Only*"

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -8,11 +8,11 @@ import pytest
 import yaml
 
 from taegis_magic.core.macros import (
-    DEFAULT_MACROS_PATH,
+    DEFAULT_MACROS_RESOURCE,
     MACROS_SECTION,
     _build_tenants_queries,
     _fetch_tenant_ids,
-    get_macros_config_path,
+    _get_custom_macros_path,
     load_macros,
     resolve_tenants,
 )
@@ -55,15 +55,15 @@ def empty_yaml_file(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-class TestGetMacrosConfigPath:
-    def test_returns_default_when_no_config(self):
+class TestGetCustomMacrosPath:
+    def test_returns_none_when_no_config(self):
         mock_config = MagicMock()
         mock_config.has_section.return_value = False
 
         with patch("taegis_magic.core.macros.get_config", return_value=mock_config):
-            result = get_macros_config_path()
+            result = _get_custom_macros_path()
 
-        assert result == DEFAULT_MACROS_PATH
+        assert result is None
 
     def test_returns_custom_path_when_configured(self, tmp_path):
         custom_file = tmp_path / "custom_macros.yaml"
@@ -75,20 +75,20 @@ class TestGetMacrosConfigPath:
         mock_config.get.return_value = str(custom_file)
 
         with patch("taegis_magic.core.macros.get_config", return_value=mock_config):
-            result = get_macros_config_path()
+            result = _get_custom_macros_path()
 
         assert result == custom_file
 
-    def test_falls_back_when_custom_path_missing(self):
+    def test_returns_none_when_custom_path_missing(self):
         mock_config = MagicMock()
         mock_config.has_section.return_value = True
         mock_config.has_option.return_value = True
         mock_config.get.return_value = "/nonexistent/macros.yaml"
 
         with patch("taegis_magic.core.macros.get_config", return_value=mock_config):
-            result = get_macros_config_path()
+            result = _get_custom_macros_path()
 
-        assert result == DEFAULT_MACROS_PATH
+        assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -114,8 +114,14 @@ class TestLoadMacros:
         macros = load_macros(empty_yaml_file)
         assert macros == {}
 
-    def test_loads_default_macros_file(self):
-        macros = load_macros(DEFAULT_MACROS_PATH)
+    def test_loads_default_macros_resource(self):
+        """Loading with no args and no custom config uses the bundled resource."""
+        mock_config = MagicMock()
+        mock_config.has_section.return_value = False
+
+        with patch("taegis_magic.core.macros.get_config", return_value=mock_config):
+            macros = load_macros()
+
         assert "mdr" in macros
         assert "services" in macros["mdr"]
 

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -246,7 +246,8 @@ class TestFetchTenantIds:
         queries = _build_tenants_queries({"services": ["MDR"]})
         result = _fetch_tenant_ids(queries, region="charlie")
 
-        assert result == ["100", "200"]
+        assert set(result) == {"100", "200"}
+        assert len(result) == 2
         mock_service.tenants4.query.tenants.assert_called_once()
 
     @patch("taegis_magic.core.macros.get_service")
@@ -268,7 +269,8 @@ class TestFetchTenantIds:
         queries = _build_tenants_queries({"services": ["MDR"]})
         result = _fetch_tenant_ids(queries, region="charlie")
 
-        assert result == ["100", "200"]
+        assert set(result) == {"100", "200"}
+        assert len(result) == 2
         assert mock_service.tenants4.query.tenants.call_count == 2
 
     @patch("taegis_magic.core.macros.get_service")
@@ -290,5 +292,6 @@ class TestFetchTenantIds:
         queries = _build_tenants_queries({"services": ["MDR", "MXDR POC"]})
         result = _fetch_tenant_ids(queries, region="charlie")
 
-        assert result == ["100", "200", "300"]
+        assert set(result) == {"100", "200", "300"}
+        assert len(result) == 3
         assert mock_service.tenants4.query.tenants.call_count == 2

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -1,0 +1,288 @@
+"""Tests for taegis_magic.core.macros — Tenant Macro resolution engine."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from taegis_magic.core.macros import (
+    DEFAULT_MACROS_PATH,
+    MACROS_SECTION,
+    _build_tenants_queries,
+    _fetch_tenant_ids,
+    get_macros_config_path,
+    load_macros,
+    resolve_tenants,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_MACROS_YAML = {
+    "macros": {
+        "mdr": {
+            "services": [
+                "ManagedXDR Essentials",
+                "MDR",
+                "Dell SafeGuard MDR",
+            ],
+        }
+    }
+}
+
+
+@pytest.fixture
+def macros_yaml_file(tmp_path):
+    """Write sample macros YAML to a temp file."""
+    path = tmp_path / "macros.yaml"
+    path.write_text(yaml.dump(SAMPLE_MACROS_YAML))
+    return path
+
+
+@pytest.fixture
+def empty_yaml_file(tmp_path):
+    path = tmp_path / "empty.yaml"
+    path.write_text("")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# get_macros_config_path
+# ---------------------------------------------------------------------------
+
+
+class TestGetMacrosConfigPath:
+    def test_returns_default_when_no_config(self):
+        mock_config = MagicMock()
+        mock_config.has_section.return_value = False
+
+        with patch("taegis_magic.core.macros.get_config", return_value=mock_config):
+            result = get_macros_config_path()
+
+        assert result == DEFAULT_MACROS_PATH
+
+    def test_returns_custom_path_when_configured(self, tmp_path):
+        custom_file = tmp_path / "custom_macros.yaml"
+        custom_file.write_text("macros: {}")
+
+        mock_config = MagicMock()
+        mock_config.has_section.return_value = True
+        mock_config.has_option.return_value = True
+        mock_config.get.return_value = str(custom_file)
+
+        with patch("taegis_magic.core.macros.get_config", return_value=mock_config):
+            result = get_macros_config_path()
+
+        assert result == custom_file
+
+    def test_falls_back_when_custom_path_missing(self):
+        mock_config = MagicMock()
+        mock_config.has_section.return_value = True
+        mock_config.has_option.return_value = True
+        mock_config.get.return_value = "/nonexistent/macros.yaml"
+
+        with patch("taegis_magic.core.macros.get_config", return_value=mock_config):
+            result = get_macros_config_path()
+
+        assert result == DEFAULT_MACROS_PATH
+
+
+# ---------------------------------------------------------------------------
+# load_macros
+# ---------------------------------------------------------------------------
+
+
+class TestLoadMacros:
+    def test_loads_macros_from_file(self, macros_yaml_file):
+        macros = load_macros(macros_yaml_file)
+        assert "mdr" in macros
+        assert macros["mdr"]["services"] == [
+            "ManagedXDR Essentials",
+            "MDR",
+            "Dell SafeGuard MDR",
+        ]
+
+    def test_returns_empty_for_missing_file(self, tmp_path):
+        macros = load_macros(tmp_path / "does_not_exist.yaml")
+        assert macros == {}
+
+    def test_returns_empty_for_empty_file(self, empty_yaml_file):
+        macros = load_macros(empty_yaml_file)
+        assert macros == {}
+
+    def test_loads_default_macros_file(self):
+        macros = load_macros(DEFAULT_MACROS_PATH)
+        assert "mdr" in macros
+        assert "services" in macros["mdr"]
+
+
+# ---------------------------------------------------------------------------
+# _build_tenants_query
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTenantsQueries:
+    def test_services_produce_one_query_per_service(self):
+        """Multiple services → one query each (OR semantics)."""
+        macro_def = {"services": ["MDR", "MXDR POC"]}
+        queries = _build_tenants_queries(macro_def)
+
+        assert len(queries) == 2
+        assert queries[0].subscriptions_match[0].name == "MDR"
+        assert queries[1].subscriptions_match[0].name == "MXDR POC"
+
+    def test_single_service_produces_single_query(self):
+        macro_def = {"services": ["MDR"]}
+        queries = _build_tenants_queries(macro_def)
+
+        assert len(queries) == 1
+        assert len(queries[0].subscriptions_match) == 1
+        assert queries[0].subscriptions_match[0].name == "MDR"
+
+    def test_empty_macro_returns_single_empty_query(self):
+        queries = _build_tenants_queries({})
+        assert len(queries) == 1
+        assert queries[0].subscriptions_match is None
+        assert queries[0].names is None
+
+    def test_services_with_base_filters_propagated(self):
+        """Base filters like enabled should appear on every per-service query."""
+        macro_def = {
+            "services": ["MDR", "MXDR POC"]
+        }
+        queries = _build_tenants_queries(macro_def)
+        assert len(queries) == 2
+
+
+# ---------------------------------------------------------------------------
+# resolve_tenants
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeTenantV4:
+    id: str
+    name: str = ""
+
+
+@dataclass
+class FakeTenantResults:
+    tenants: list
+    has_more: bool = False
+    cursor_pos: str = None
+    count: int = 0
+
+
+class TestResolveTenants:
+    def test_passthrough_for_none(self):
+        result = resolve_tenants(None)
+        assert result == [None]
+
+    def test_passthrough_for_plain_id(self):
+        result = resolve_tenants("12345")
+        assert result == ["12345"]
+
+    def test_passthrough_for_non_macro_string(self):
+        result = resolve_tenants("my-tenant")
+        assert result == ["my-tenant"]
+
+    @patch("taegis_magic.core.macros.load_macros")
+    @patch("taegis_magic.core.macros._fetch_tenant_ids")
+    def test_resolves_macro(self, mock_fetch, mock_load):
+        mock_load.return_value = {
+            "mdr": {"services": ["MDR"]},
+        }
+        mock_fetch.return_value = ["111", "222", "333"]
+
+        result = resolve_tenants("@mdr", region="charlie")
+
+        assert result == ["111", "222", "333"]
+        mock_fetch.assert_called_once()
+
+    @patch("taegis_magic.core.macros.load_macros")
+    def test_raises_for_unknown_macro(self, mock_load):
+        mock_load.return_value = {"mdr": {"services": ["MDR"]}}
+
+        with pytest.raises(ValueError, match="Unknown tenant macro '@nope'"):
+            resolve_tenants("@nope")
+
+    @patch("taegis_magic.core.macros.load_macros")
+    @patch("taegis_magic.core.macros._fetch_tenant_ids")
+    def test_returns_empty_list_for_no_matches(self, mock_fetch, mock_load):
+        mock_load.return_value = {"empty": {"names": ["DoesNotExist*"]}}
+        mock_fetch.return_value = []
+
+        result = resolve_tenants("@empty")
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_tenant_ids (with pagination)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchTenantIds:
+    @patch("taegis_magic.core.macros.get_service")
+    def test_single_query_single_page(self, mock_get_service):
+        mock_service = MagicMock()
+        mock_get_service.return_value = mock_service
+
+        mock_service.tenants4.query.tenants.return_value = FakeTenantResults(
+            tenants=[FakeTenantV4(id="100"), FakeTenantV4(id="200")],
+            has_more=False,
+        )
+
+        queries = _build_tenants_queries({"services": ["MDR"]})
+        result = _fetch_tenant_ids(queries, region="charlie")
+
+        assert result == ["100", "200"]
+        mock_service.tenants4.query.tenants.assert_called_once()
+
+    @patch("taegis_magic.core.macros.get_service")
+    def test_pagination(self, mock_get_service):
+        mock_service = MagicMock()
+        mock_get_service.return_value = mock_service
+
+        page1 = FakeTenantResults(
+            tenants=[FakeTenantV4(id="100")],
+            has_more=True,
+            cursor_pos="cursor-1",
+        )
+        page2 = FakeTenantResults(
+            tenants=[FakeTenantV4(id="200")],
+            has_more=False,
+        )
+        mock_service.tenants4.query.tenants.side_effect = [page1, page2]
+
+        queries = _build_tenants_queries({"services": ["MDR"]})
+        result = _fetch_tenant_ids(queries, region="charlie")
+
+        assert result == ["100", "200"]
+        assert mock_service.tenants4.query.tenants.call_count == 2
+
+    @patch("taegis_magic.core.macros.get_service")
+    def test_multiple_services_unioned_and_deduplicated(self, mock_get_service):
+        """Two services that share a tenant → deduplicated in output."""
+        mock_service = MagicMock()
+        mock_get_service.return_value = mock_service
+
+        result_mdr = FakeTenantResults(
+            tenants=[FakeTenantV4(id="100"), FakeTenantV4(id="200")],
+            has_more=False,
+        )
+        result_mxdr = FakeTenantResults(
+            tenants=[FakeTenantV4(id="200"), FakeTenantV4(id="300")],
+            has_more=False,
+        )
+        mock_service.tenants4.query.tenants.side_effect = [result_mdr, result_mxdr]
+
+        queries = _build_tenants_queries({"services": ["MDR", "MXDR POC"]})
+        result = _fetch_tenant_ids(queries, region="charlie")
+
+        assert result == ["100", "200", "300"]
+        assert mock_service.tenants4.query.tenants.call_count == 2

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,0 +1,80 @@
+"""Tests for merge_normalizer_results in taegis_magic.core.normalizer."""
+
+from taegis_magic.core.normalizer import (
+    TaegisResultsNormalizer,
+    merge_normalizer_results,
+)
+
+
+class TestMergeNormalizerResults:
+    def test_empty_list_returns_empty_normalizer(self):
+        result = merge_normalizer_results([])
+        assert result.tenant_id == "None"
+        assert result.results == []
+
+    def test_single_result_returned_as_is(self):
+        normalizer = TaegisResultsNormalizer(
+            service="alerts",
+            tenant_id="111",
+            region="charlie",
+            raw_results=[{"id": "a1"}],
+        )
+        result = merge_normalizer_results([normalizer])
+
+        assert result is normalizer
+        assert result.tenant_id == "111"
+
+    def test_merges_multiple_results(self):
+        n1 = TaegisResultsNormalizer(
+            service="alerts",
+            tenant_id="111",
+            region="charlie",
+            raw_results=[{"id": "a1"}, {"id": "a2"}],
+        )
+        n2 = TaegisResultsNormalizer(
+            service="alerts",
+            tenant_id="222",
+            region="charlie",
+            raw_results=[{"id": "b1"}],
+        )
+
+        result = merge_normalizer_results([n1, n2])
+
+        assert result.tenant_id == "111, 222"
+        assert result.service == "alerts"
+        assert result.region == "charlie"
+        assert len(result.results) == 3
+
+    def test_tags_records_with_macro_tenant_id(self):
+        n1 = TaegisResultsNormalizer(
+            service="alerts",
+            tenant_id="111",
+            region="charlie",
+            raw_results=[{"id": "a1"}],
+        )
+        n2 = TaegisResultsNormalizer(
+            service="alerts",
+            tenant_id="222",
+            region="charlie",
+            raw_results=[{"id": "b1"}],
+        )
+
+        result = merge_normalizer_results([n1, n2])
+
+        assert result.results[0]["_macro_tenant_id"] == "111"
+        assert result.results[1]["_macro_tenant_id"] == "222"
+
+    def test_preserves_original_record_fields(self):
+        n1 = TaegisResultsNormalizer(
+            service="events",
+            tenant_id="111",
+            region="delta",
+            raw_results=[{"id": "e1", "severity": "high"}],
+        )
+
+        result = merge_normalizer_results([n1, n1])
+
+        for record in result.results:
+            assert "id" in record
+            assert "severity" in record
+            assert record["severity"] == "high"


### PR DESCRIPTION
Issue: #98 

### Description
Adds the ability to expand Taegis Magic commands to a series of tenants using an @macro within the --tenant flag. Macros are defined in a YAML resource file and resolved at runtime via the tenantsv4 API.

### Architecture
The macro system is implemented as a standalone resolution engine that can be integrated into any command accepting --tenant:
Detection : If --tenant value starts with @, treat it as a macro
YAML lookup : Load macro definition from a configurable YAML resource
Translation : Convert user-friendly YAML fields (e.g., services: [...]) into tenantsv4 TenantsQuery input types
Resolution : Query tenantsv4 API (one query per service for OR semantics, deduplicated)
Execution : Run the command once per resolved tenant, merge results

### Configuration
Users can customize the macro resource path:
```
taegis configure macros list — Show available macros and resource path
taegis configure macros path <file> — Set a custom YAML resource
taegis configure macros reset — Reset to bundled default
```

### Example usage:
```
%%taegis alerts search --tenant @mdr  --region charlie
FROM alert
where
EARLIEST=-10d|head 1
```

### Follow-up Work
1. Only **alerts** search is wired up for sample tests, other commands (events, tenants, threat, etc.) need integration
2. Multi-tenant merge returns TaegisResultsNormalizer instead of command-specific normalizer types (e.g., AlertsResultsNormalizer) 

### Testing
`./taegis_env/bin/python3 -m pytest tests/ -v`