### PR TITLE
fix: handle None process_list in process_children (issue #113)

### DIFF
--- a/taegis_magic/commands/process_trees.py
+++ b/taegis_magic/commands/process_trees.py
@@ -113,7 +113,7 @@ def process_children(
             next_token=next_token,
         )
 
-        all_results.extend(results.process_list)
+        all_results.extend(results.process_list or [])
         next_token = results.next_token
         if not next_token:
             break


### PR DESCRIPTION
## Summary

Fix `TypeError: 'NoneType' object is not iterable` in `process_children` when a process has no children.

## Problem

`results.process_list` can be `None` when a process has no children, but `all_results.extend()` was called directly on it without a None check. This caused a `TypeError` that was logged as an exception in `process_children`.

## Fix

Changed `all_results.extend(results.process_list)` to `all_results.extend(results.process_list or [])` to handle the case where `process_list` is `None`.

## Changes

- `taegis_magic/commands/process_trees.py`: Added `or []` fallback for `results.process_list` in the `process_children` function.

Fixes #113