### PR TITLE
Issue 133: Add taegis query command

### DIFF
--- a/Query.ipynb
+++ b/Query.ipynb
@@ -1,0 +1,355 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ef7e9f7a-84ed-4069-a359-6bdf4e698ad0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext taegis_magic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ce3af927-b031-4507-8d43-d1f13b25071a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1;34musage: \u001b[0m\u001b[1;35mtaegis_magic_parser\u001b[0m [\u001b[32m-h\u001b[0m] [\u001b[36m--assign \u001b[33mNAME\u001b[0m | \u001b[36m--append \u001b[33mNAME\u001b[0m]\n",
+      "                           [\u001b[36m--display \u001b[33mNAME\u001b[0m]\n",
+      "                           [\u001b[36m--disable-return-display \u001b[33m{off,all,on_empty}\u001b[0m]\n",
+      "                           [\u001b[36m--cell \u001b[33mCELL\u001b[0m] [\u001b[32m-t\u001b[0m] [\u001b[32m-f \u001b[33mCELL_TEMPLATE_FILE\u001b[0m]\n",
+      "                           [\u001b[36m--cache\u001b[0m]\n",
+      "\n",
+      "\u001b[1;34moptions:\u001b[0m\n",
+      "  \u001b[1;32m-h\u001b[0m, \u001b[1;36m--help\u001b[0m            show this help message and exit\n",
+      "  \u001b[1;36m--assign\u001b[0m \u001b[1;33mNAME\u001b[0m         Assign results as pandas DataFrame to NAME\n",
+      "  \u001b[1;36m--append\u001b[0m \u001b[1;33mNAME\u001b[0m         Append results as pandas DataFrame to NAME\n",
+      "  \u001b[1;36m--display\u001b[0m \u001b[1;33mNAME\u001b[0m        Display NAME as markdown table\n",
+      "  \u001b[1;36m--disable-return-display\u001b[0m \u001b[1;33m{off,all,on_empty}\u001b[0m\n",
+      "                        Disable automatic display of return metadata table,\n",
+      "                        does not work with --cache\n",
+      "  \u001b[1;36m--cell\u001b[0m \u001b[1;33mCELL\u001b[0m           Cell contents\n",
+      "  \u001b[1;32m-t\u001b[0m, \u001b[1;36m--cell-template\u001b[0m   Use a Jinja2 Template for input, uses Shell Namespace\n",
+      "                        as variables\n",
+      "  \u001b[1;32m-f\u001b[0m, \u001b[1;36m--cell-template-file\u001b[0m \u001b[1;33mCELL_TEMPLATE_FILE\u001b[0m\n",
+      "                        Use a template file instead of providing cell input\n",
+      "  \u001b[1;36m--cache\u001b[0m               Save output to cache / Load output from cache (if\n",
+      "                        present)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">                                                                                                                   </span>\n",
+       "<span style=\"font-weight: bold\"> </span><span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">Usage: </span><span style=\"font-weight: bold\">taegis [OPTIONS] COMMAND [ARGS]...                                                                         </span>\n",
+       "<span style=\"font-weight: bold\">                                                                                                                   </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m                                                                                                                   \u001b[0m\n",
+       "\u001b[1m \u001b[0m\u001b[1;33mUsage: \u001b[0m\u001b[1mtaegis [OPTIONS] COMMAND [ARGS]...\u001b[0m\u001b[1m                                                                        \u001b[0m\u001b[1m \u001b[0m\n",
+       "\u001b[1m                                                                                                                   \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> Taegis Magic help menu.                                                                                           \n",
+       "                                                                                                                   \n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       " Taegis Magic help menu.                                                                                           \n",
+       "                                                                                                                   \n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────╮</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">--warning</span>                 <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">--no-warning</span>          Set taegis_magic logger level for this command.                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">[default: no-warning]                          </span>                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">--verbose</span>                 <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">--no-verbose</span>          Set taegis_magic logger level for this command.                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">[default: no-verbose]                          </span>                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">--debug</span>                   <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">--no-debug</span>            Set taegis_magic logger level for this command.                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">[default: no-debug]                            </span>                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">--trace</span>                   <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">--no-trace</span>            Set taegis_magic logger level for this command.                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">[default: no-trace]                            </span>                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">--error</span>                   <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">--no-error</span>            Set taegis_magic logger level for this command.                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">[default: no-error]                            </span>                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">--sdk-warning</span>             <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">--no-sdk-warning</span>      Set taegis_sdk_python logger level for this command.            <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">[default: no-sdk-warning]                           </span>            <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">--sdk-verbose</span>             <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">--no-sdk-verbose</span>      Set taegis_sdk_python logger level for this command.            <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">[default: no-sdk-verbose]                           </span>            <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">--sdk-debug</span>               <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">--no-sdk-debug</span>        Set taegis_sdk_python logger level for this command.            <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">[default: no-sdk-debug]                             </span>            <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">--sdk-error</span>               <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">--no-sdk-error</span>        Set taegis_sdk_python logger level for this command.            <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">[default: no-sdk-error]                             </span>            <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">--install-completion</span>                            Install completion for the current shell.                       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">--show-completion</span>                               Show completion for the current shell, to copy it or customize  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>                                                 the installation.                                               <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">--help</span>                <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">-h</span>                        Show this message and exit.                                     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2m╭─\u001b[0m\u001b[2m Options \u001b[0m\u001b[2m──────────────────────────────────────────────────────────────────────────────────────────────────────\u001b[0m\u001b[2m─╮\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36m-\u001b[0m\u001b[1;36m-warning\u001b[0m                 \u001b[1;35m-\u001b[0m\u001b[1;35m-no\u001b[0m\u001b[1;35m-warning\u001b[0m          Set taegis_magic logger level for this command.                 \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m                                                 \u001b[2m[default: no-warning]                          \u001b[0m                 \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36m-\u001b[0m\u001b[1;36m-verbose\u001b[0m                 \u001b[1;35m-\u001b[0m\u001b[1;35m-no\u001b[0m\u001b[1;35m-verbose\u001b[0m          Set taegis_magic logger level for this command.                 \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m                                                 \u001b[2m[default: no-verbose]                          \u001b[0m                 \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36m-\u001b[0m\u001b[1;36m-debug\u001b[0m                   \u001b[1;35m-\u001b[0m\u001b[1;35m-no\u001b[0m\u001b[1;35m-debug\u001b[0m            Set taegis_magic logger level for this command.                 \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m                                                 \u001b[2m[default: no-debug]                            \u001b[0m                 \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36m-\u001b[0m\u001b[1;36m-trace\u001b[0m                   \u001b[1;35m-\u001b[0m\u001b[1;35m-no\u001b[0m\u001b[1;35m-trace\u001b[0m            Set taegis_magic logger level for this command.                 \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m                                                 \u001b[2m[default: no-trace]                            \u001b[0m                 \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36m-\u001b[0m\u001b[1;36m-error\u001b[0m                   \u001b[1;35m-\u001b[0m\u001b[1;35m-no\u001b[0m\u001b[1;35m-error\u001b[0m            Set taegis_magic logger level for this command.                 \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m                                                 \u001b[2m[default: no-error]                            \u001b[0m                 \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36m-\u001b[0m\u001b[1;36m-sdk\u001b[0m\u001b[1;36m-warning\u001b[0m             \u001b[1;35m-\u001b[0m\u001b[1;35m-no\u001b[0m\u001b[1;35m-sdk-warning\u001b[0m      Set taegis_sdk_python logger level for this command.            \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m                                                 \u001b[2m[default: no-sdk-warning]                           \u001b[0m            \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36m-\u001b[0m\u001b[1;36m-sdk\u001b[0m\u001b[1;36m-verbose\u001b[0m             \u001b[1;35m-\u001b[0m\u001b[1;35m-no\u001b[0m\u001b[1;35m-sdk-verbose\u001b[0m      Set taegis_sdk_python logger level for this command.            \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m                                                 \u001b[2m[default: no-sdk-verbose]                           \u001b[0m            \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36m-\u001b[0m\u001b[1;36m-sdk\u001b[0m\u001b[1;36m-debug\u001b[0m               \u001b[1;35m-\u001b[0m\u001b[1;35m-no\u001b[0m\u001b[1;35m-sdk-debug\u001b[0m        Set taegis_sdk_python logger level for this command.            \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m                                                 \u001b[2m[default: no-sdk-debug]                             \u001b[0m            \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36m-\u001b[0m\u001b[1;36m-sdk\u001b[0m\u001b[1;36m-error\u001b[0m               \u001b[1;35m-\u001b[0m\u001b[1;35m-no\u001b[0m\u001b[1;35m-sdk-error\u001b[0m        Set taegis_sdk_python logger level for this command.            \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m                                                 \u001b[2m[default: no-sdk-error]                             \u001b[0m            \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36m-\u001b[0m\u001b[1;36m-install\u001b[0m\u001b[1;36m-completion\u001b[0m                            Install completion for the current shell.                       \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36m-\u001b[0m\u001b[1;36m-show\u001b[0m\u001b[1;36m-completion\u001b[0m                               Show completion for the current shell, to copy it or customize  \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m                                                 the installation.                                               \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36m-\u001b[0m\u001b[1;36m-help\u001b[0m                \u001b[1;32m-h\u001b[0m                        Show this message and exit.                                     \u001b[2m│\u001b[0m\n",
+       "\u001b[2m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">╭─ Commands ──────────────────────────────────────────────────────────────────────────────────────────────────────╮</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">version         </span> Taegis Magic version information.                                                              <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">alerts          </span> Taegis Alerts Commands.                                                                        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">auth            </span> Taegis Authentication Commands.                                                                <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">audits          </span> Taegis Audit Commands.                                                                         <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">clients         </span> Taegis Clients Commands.                                                                       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">configure       </span> Taegis Magic Configuration Commands.                                                           <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">events          </span> Taegis Events Commands.                                                                        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">investigations  </span> Taegis Investigation Commands.                                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">notebook        </span> Taegis Notebook Commands.                                                                      <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">preferences     </span> Taegis Preferences Commands.                                                                   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">rules           </span> Taegis Rules Commands.                                                                         <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">search          </span> Taegis Search Commands.                                                                        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">sharelinks      </span> Taegis Sharelinks Commands.                                                                    <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">subjects        </span> Taegis Subjects Commands.                                                                      <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">tenant-profiles </span> Taegis Tenant Profile Commands.                                                                <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">tenants         </span> Taegis Tenant Commands.                                                                        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">threat          </span> Taegis Threat Intelligence Commands.                                                           <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">users           </span> Taegis User Commands.                                                                          <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">process-trees   </span> Taegis Process Trees Commands.                                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">query           </span> Taegis Query Relay Commands.                                                                   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">orchestration   </span> Taegis Orchestration Commands.                                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2m╭─\u001b[0m\u001b[2m Commands \u001b[0m\u001b[2m─────────────────────────────────────────────────────────────────────────────────────────────────────\u001b[0m\u001b[2m─╮\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36mversion        \u001b[0m\u001b[1;36m \u001b[0m Taegis Magic version information.                                                              \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36malerts         \u001b[0m\u001b[1;36m \u001b[0m Taegis Alerts Commands.                                                                        \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36mauth           \u001b[0m\u001b[1;36m \u001b[0m Taegis Authentication Commands.                                                                \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36maudits         \u001b[0m\u001b[1;36m \u001b[0m Taegis Audit Commands.                                                                         \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36mclients        \u001b[0m\u001b[1;36m \u001b[0m Taegis Clients Commands.                                                                       \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36mconfigure      \u001b[0m\u001b[1;36m \u001b[0m Taegis Magic Configuration Commands.                                                           \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36mevents         \u001b[0m\u001b[1;36m \u001b[0m Taegis Events Commands.                                                                        \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36minvestigations \u001b[0m\u001b[1;36m \u001b[0m Taegis Investigation Commands.                                                                 \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36mnotebook       \u001b[0m\u001b[1;36m \u001b[0m Taegis Notebook Commands.                                                                      \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36mpreferences    \u001b[0m\u001b[1;36m \u001b[0m Taegis Preferences Commands.                                                                   \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36mrules          \u001b[0m\u001b[1;36m \u001b[0m Taegis Rules Commands.                                                                         \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36msearch         \u001b[0m\u001b[1;36m \u001b[0m Taegis Search Commands.                                                                        \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36msharelinks     \u001b[0m\u001b[1;36m \u001b[0m Taegis Sharelinks Commands.                                                                    \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36msubjects       \u001b[0m\u001b[1;36m \u001b[0m Taegis Subjects Commands.                                                                      \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36mtenant-profiles\u001b[0m\u001b[1;36m \u001b[0m Taegis Tenant Profile Commands.                                                                \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36mtenants        \u001b[0m\u001b[1;36m \u001b[0m Taegis Tenant Commands.                                                                        \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36mthreat         \u001b[0m\u001b[1;36m \u001b[0m Taegis Threat Intelligence Commands.                                                           \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36musers          \u001b[0m\u001b[1;36m \u001b[0m Taegis User Commands.                                                                          \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36mprocess-trees  \u001b[0m\u001b[1;36m \u001b[0m Taegis Process Trees Commands.                                                                 \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36mquery          \u001b[0m\u001b[1;36m \u001b[0m Taegis Query Relay Commands.                                                                   \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36morchestration  \u001b[0m\u001b[1;36m \u001b[0m Taegis Orchestration Commands.                                                                 \u001b[2m│\u001b[0m\n",
+       "\u001b[2m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%taegis -h"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "768ad961-6633-4663-8528-99005752642b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from taegis_sdk_python.config import write_to_config\n",
+    "write_to_config(\"magics.regions\", \"pilot\", \"https://api.pilot.8labs.io\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d2cd6e07-098f-4112-9194-bc8025c0d5c2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3f1ad754ea8340d6b12f50e64ffc3938",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Executing query: 0 poll [00:00, ?poll/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "914f05a694d045f59ccd5794b9fd61f4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Fetching results:   0%|          | 0/5 [00:00<?, ?rows/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "**Taegis Results**\n",
+       "\n",
+       "|Region          |Tenant             |Service          |Total Results                       |\n",
+       "|----------------|-------------------|-----------------|------------------------------------|\n",
+       "|pilot|93387|query_relay|5000|"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%taegis query --cell \"SELECT * FROM process LIMIT 5000\" --time-range-start \"2026-06-10T00:00:00Z\" --time-range-end \"2026-06-11T00:00:00Z\" --tenant 93387 --workload \"search-qee-runner\" --region  pilot --assign process"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c10b22f0-1152-4739-8908-fb994af30873",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f562a5b48df14b2c99bd27cd2e6804ed",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Executing query: 0 poll [00:00, ?poll/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c250a471caec44feb1535bb0591ff6d0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Fetching results:   0%|          | 0/5 [00:00<?, ?rows/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "**Taegis Results**\n",
+       "\n",
+       "|Region          |Tenant             |Service          |Total Results                       |\n",
+       "|----------------|-------------------|-----------------|------------------------------------|\n",
+       "|pilot|93387|query_relay|5000|"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%taegis query --tenant 93387 --workload \"search-qee-runner\" --region  pilot --assign process\n",
+    "SELECT \n",
+    "    * \n",
+    "FROM process \n",
+    "LIMIT 5000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f18a02b-48f4-47f5-8479-3ab2130bf90c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/query.ipynb
+++ b/examples/query.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 2,
    "id": "ce3af927-b031-4507-8d43-d1f13b25071a",
    "metadata": {},
    "outputs": [
@@ -157,7 +157,7 @@
        "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">threat          </span> Taegis Threat Intelligence Commands.                                                           <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
        "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">users           </span> Taegis User Commands.                                                                          <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
        "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">process-trees   </span> Taegis Process Trees Commands.                                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
-       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">query           </span> Taegis Query Relay Commands.                                                                   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
+       "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">query           </span> Taegis Query Commands.                                                                         <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
        "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">orchestration   </span> Taegis Orchestration Commands.                                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│</span>\n",
        "<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
        "</pre>\n"
@@ -183,7 +183,7 @@
        "\u001b[2m│\u001b[0m \u001b[1;36mthreat         \u001b[0m\u001b[1;36m \u001b[0m Taegis Threat Intelligence Commands.                                                           \u001b[2m│\u001b[0m\n",
        "\u001b[2m│\u001b[0m \u001b[1;36musers          \u001b[0m\u001b[1;36m \u001b[0m Taegis User Commands.                                                                          \u001b[2m│\u001b[0m\n",
        "\u001b[2m│\u001b[0m \u001b[1;36mprocess-trees  \u001b[0m\u001b[1;36m \u001b[0m Taegis Process Trees Commands.                                                                 \u001b[2m│\u001b[0m\n",
-       "\u001b[2m│\u001b[0m \u001b[1;36mquery          \u001b[0m\u001b[1;36m \u001b[0m Taegis Query Relay Commands.                                                                   \u001b[2m│\u001b[0m\n",
+       "\u001b[2m│\u001b[0m \u001b[1;36mquery          \u001b[0m\u001b[1;36m \u001b[0m Taegis Query Commands.                                                                         \u001b[2m│\u001b[0m\n",
        "\u001b[2m│\u001b[0m \u001b[1;36morchestration  \u001b[0m\u001b[1;36m \u001b[0m Taegis Orchestration Commands.                                                                 \u001b[2m│\u001b[0m\n",
        "\u001b[2m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
       ]
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 3,
    "id": "768ad961-6633-4663-8528-99005752642b",
    "metadata": {},
    "outputs": [],
@@ -216,14 +216,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "d2cd6e07-098f-4112-9194-bc8025c0d5c2",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Copy URL into a browser: https://api.pilot.8labs.io/auth/device/code/activate?user_code=K9DD-KNMG\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3f1ad754ea8340d6b12f50e64ffc3938",
+       "model_id": "5732ea19c8b1448387304f55a29039e5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -237,7 +244,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "914f05a694d045f59ccd5794b9fd61f4",
+       "model_id": "3615eef387c74d5c9f4c74687856cc5a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -268,14 +275,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "c10b22f0-1152-4739-8908-fb994af30873",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f562a5b48df14b2c99bd27cd2e6804ed",
+       "model_id": "f3d7378c90bc49d09dc0bc455e2b9828",
        "version_major": 2,
        "version_minor": 0
       },
@@ -289,7 +296,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c250a471caec44feb1535bb0591ff6d0",
+       "model_id": "8c2b5f2839d34fc9a55d92eae987bc66",
        "version_major": 2,
        "version_minor": 0
       },
@@ -324,8 +331,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "2f18a02b-48f4-47f5-8479-3ab2130bf90c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-07-14 00:35:52,138::ERROR::taegis_magic.commands.query_relay::Query Relay execution failed to start: QueryRelayStatus.UNKNOWN error=INVALID_QUERY message=filtering by 'tenant' is not allowed — tenant isolation is applied automatically code=None\n",
+      "2026-07-14 00:35:52,140::ERROR::taegis_magic.commands.query_relay::Exception raised in search. exception: Query Relay execution failed to start: QueryRelayStatus.UNKNOWN error=INVALID_QUERY message=filtering by 'tenant' is not allowed — tenant isolation is applied automatically code=None\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%taegis query --tenant 93387 --workload \"search-qee-runner\" --region  pilot --assign process\n",
+    "SELECT \n",
+    "    * \n",
+    "FROM process \n",
+    "WHERE \n",
+    "    tenant='5000'\n",
+    "LIMIT 5000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ef287ca-bc6d-4aaa-af5c-c08d4bbcbf66",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/examples/query.ipynb
+++ b/examples/query.ipynb
@@ -221,16 +221,9 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Copy URL into a browser: https://api.pilot.8labs.io/auth/device/code/activate?user_code=K9DD-KNMG\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5732ea19c8b1448387304f55a29039e5",
+       "model_id": "26753679a4e44e3887c121e8fe733d3f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -244,7 +237,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3615eef387c74d5c9f4c74687856cc5a",
+       "model_id": "d7f6a27311f148c9bec1b32479eb0e75",
        "version_major": 2,
        "version_minor": 0
       },
@@ -270,19 +263,19 @@
     }
    ],
    "source": [
-    "%taegis query --cell \"SELECT * FROM process LIMIT 5000\" --time-range-start \"2026-06-10T00:00:00Z\" --time-range-end \"2026-06-11T00:00:00Z\" --tenant 93387 --workload \"search-qee-runner\" --region  pilot --assign process"
+    "%taegis query search --cell \"SELECT * FROM process LIMIT 5000\" --time-range-start \"2026-06-10T00:00:00Z\" --time-range-end \"2026-06-11T00:00:00Z\" --tenant 93387 --workload \"search-qee-runner\" --region  pilot --assign process"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "c10b22f0-1152-4739-8908-fb994af30873",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f3d7378c90bc49d09dc0bc455e2b9828",
+       "model_id": "c6a45ab208f54a679216a40e6411c915",
        "version_major": 2,
        "version_minor": 0
       },
@@ -296,7 +289,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8c2b5f2839d34fc9a55d92eae987bc66",
+       "model_id": "24ccfc51426a4edc921774927457e870",
        "version_major": 2,
        "version_minor": 0
       },
@@ -322,45 +315,12 @@
     }
    ],
    "source": [
-    "%%taegis query --tenant 93387 --workload \"search-qee-runner\" --region  pilot --assign process\n",
+    "%%taegis query search --tenant 93387 --workload \"search-qee-runner\" --region  pilot --assign process\n",
     "SELECT \n",
     "    * \n",
     "FROM process \n",
     "LIMIT 5000"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "2f18a02b-48f4-47f5-8479-3ab2130bf90c",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-07-14 00:35:52,138::ERROR::taegis_magic.commands.query_relay::Query Relay execution failed to start: QueryRelayStatus.UNKNOWN error=INVALID_QUERY message=filtering by 'tenant' is not allowed — tenant isolation is applied automatically code=None\n",
-      "2026-07-14 00:35:52,140::ERROR::taegis_magic.commands.query_relay::Exception raised in search. exception: Query Relay execution failed to start: QueryRelayStatus.UNKNOWN error=INVALID_QUERY message=filtering by 'tenant' is not allowed — tenant isolation is applied automatically code=None\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%taegis query --tenant 93387 --workload \"search-qee-runner\" --region  pilot --assign process\n",
-    "SELECT \n",
-    "    * \n",
-    "FROM process \n",
-    "WHERE \n",
-    "    tenant='5000'\n",
-    "LIMIT 5000"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1ef287ca-bc6d-4aaa-af5c-c08d4bbcbf66",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "taegis-sdk-python>=v1.6.16",
+    "taegis-sdk-python>=v1.6.20",
     "ipython",
     "notebook",
     "nbformat",

--- a/taegis_magic/cli.py
+++ b/taegis_magic/cli.py
@@ -21,6 +21,7 @@ from taegis_magic.commands import (
     orchestration,
     preferences,
     process_trees,
+    query_relay,
     rules,
     search,
     sharelinks,
@@ -62,6 +63,7 @@ app.add_typer(tenants.app, name="tenants")
 app.add_typer(threat.app, name="threat")
 app.add_typer(users.app, name="users")
 app.add_typer(process_trees.app, name="process-trees")
+app.add_typer(query_relay.app, name="query")
 app.add_typer(orchestration.app, name="orchestration")
 CONFIG = configure.set_defaults()
 

--- a/taegis_magic/commands/query_relay.py
+++ b/taegis_magic/commands/query_relay.py
@@ -10,7 +10,7 @@ from dataclasses_json import dataclass_json
 from taegis_magic.core.log import tracing
 from taegis_magic.core.normalizer import TaegisResultsNormalizer
 from taegis_magic.core.service import get_service
-from taegis_sdk_python import GraphQLNoRowsInResultSetError
+from taegis_sdk_python import ServiceCoreException
 from taegis_sdk_python.services.query_relay.types import (
     ExecuteQueryRelayInput,
     FetchQueryRelayResultsInput,
@@ -86,11 +86,12 @@ def search(
     token = response.token
     if response.error:
         error = response.error
-        log.error(
+        message = (
             f"Query Relay execution failed to start: {response.status} "
             f"error={error.error} message={error.message} code={error.code}"
         )
-        raise GraphQLNoRowsInResultSetError("for mutation executeQueryRelay")
+        log.error(message)
+        raise ServiceCoreException(message)
     log.info(f"Query submitted, token: {token}")
 
     # Phase 1: Poll until execution completes
@@ -117,13 +118,14 @@ def search(
 
     if poll_response.result != QueryRelayResult.SUCCEEDED:
         error = poll_response.error
-        log.error(
+        message = (
             f"Query Relay execution did not succeed: {poll_response.result} "
             f"error={error.error if error else None} "
             f"message={error.message if error else None} "
             f"code={error.code if error else None}"
         )
-        raise GraphQLNoRowsInResultSetError("for mutation executeQueryRelay")
+        log.error(message)
+        raise ServiceCoreException(message)
 
     # Phase 2: Fetch all pages with progress
     total_rows = poll_response.pages.total if poll_response.pages else None

--- a/taegis_magic/commands/query_relay.py
+++ b/taegis_magic/commands/query_relay.py
@@ -54,7 +54,7 @@ class TaegisQueryRelayNormalizer(TaegisResultsNormalizer):
         return self.raw_results
 
 
-@app.callback(invoke_without_command=True)
+@app.command()
 @tracing
 def search(
     cell: Annotated[str, typer.Option(help="SQL query to execute")],

--- a/taegis_magic/commands/query_relay.py
+++ b/taegis_magic/commands/query_relay.py
@@ -1,0 +1,171 @@
+"""Taegis Magic query relay commands."""
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import typer
+from dataclasses_json import dataclass_json
+from taegis_magic.core.log import tracing
+from taegis_magic.core.normalizer import TaegisResultsNormalizer
+from taegis_magic.core.service import get_service
+from taegis_sdk_python import GraphQLNoRowsInResultSetError
+from taegis_sdk_python.services.query_relay.types import (
+    ExecuteQueryRelayInput,
+    FetchQueryRelayResultsInput,
+    QueryRelayResult,
+    QueryRelayStatus,
+)
+from typing_extensions import Annotated
+
+try:
+    from tqdm.auto import tqdm
+except ImportError:
+    tqdm = None
+
+log = logging.getLogger(__name__)
+
+app = typer.Typer(help="Taegis Query Commands.")
+
+POLL_INTERVAL_SECONDS = 2
+
+
+def _get_bar(total, desc, unit, disable=False):
+    if tqdm is not None:
+        kwargs = dict(desc=desc, unit=unit, disable=disable)
+        if total is not None:
+            kwargs["total"] = total
+        else:
+            kwargs["bar_format"] = "{desc}: {n_fmt} {unit} [{elapsed}, {rate_fmt}]"
+        return tqdm(**kwargs)
+    return None
+
+
+@dataclass_json
+@dataclass
+class TaegisQueryRelayNormalizer(TaegisResultsNormalizer):
+    """Taegis Query Relay Normalizer."""
+
+    raw_results: List[Dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def results(self) -> List[Dict[str, Any]]:
+        return self.raw_results
+
+
+@app.callback(invoke_without_command=True)
+@tracing
+def search(
+    cell: Annotated[str, typer.Option(help="SQL query to execute")],
+    workload: Annotated[str, typer.Option(help="QEE workload type for Trino cluster routing")],
+    time_range_start: Annotated[
+        Optional[str], typer.Option(help="ISO8601 start time")
+    ] = None,
+    time_range_end: Annotated[
+        Optional[str], typer.Option(help="ISO8601 end time")
+    ] = None,
+    page_size: Annotated[int, typer.Option(help="Results per page")] = 1000,
+    tenant: Annotated[Optional[str], typer.Option(help="Tenant ID")] = None,
+    region: Annotated[Optional[str], typer.Option(help="Taegis Region")] = None,
+    progress: Annotated[bool, typer.Option(help="Show progress bars")] = True,
+):
+    """Submit a SQL query via Query Relay and return all results."""
+    service = get_service(environment=region, tenant_id=tenant)
+    show_progress = progress and tqdm is not None
+
+    # Submit the query and get a token back
+    response = service.query_relay.mutation.execute_query_relay(
+        ExecuteQueryRelayInput(
+            sql=cell,
+            time_range_start=time_range_start,
+            time_range_end=time_range_end,
+            workload=workload,
+        )
+    )
+    token = response.token
+    if response.error:
+        error = response.error
+        log.error(
+            f"Query Relay execution failed to start: {response.status} "
+            f"error={error.error} message={error.message} code={error.code}"
+        )
+        raise GraphQLNoRowsInResultSetError("for mutation executeQueryRelay")
+    log.info(f"Query submitted, token: {token}")
+
+    # Phase 1: Poll until execution completes
+    poll_bar = _get_bar(
+        total=None, desc="Executing query", unit="poll", disable=not show_progress
+    )
+    try:
+        while True:
+            poll_response = service.query_relay.query.fetch_query_relay_results(
+                FetchQueryRelayResultsInput(token=token, page_size=page_size)
+            )
+            if poll_response.status == QueryRelayStatus.FINISHED:
+                if poll_bar is not None:
+                    poll_bar.set_description("Query finished")
+                    poll_bar.update(1)
+                break
+            if poll_bar is not None:
+                poll_bar.set_description(f"Waiting ({poll_response.status.value})")
+                poll_bar.update(1)
+            time.sleep(POLL_INTERVAL_SECONDS)
+    finally:
+        if poll_bar is not None:
+            poll_bar.close()
+
+    if poll_response.result != QueryRelayResult.SUCCEEDED:
+        error = poll_response.error
+        log.error(
+            f"Query Relay execution did not succeed: {poll_response.result} "
+            f"error={error.error if error else None} "
+            f"message={error.message if error else None} "
+            f"code={error.code if error else None}"
+        )
+        raise GraphQLNoRowsInResultSetError("for mutation executeQueryRelay")
+
+    # Phase 2: Fetch all pages with progress
+    total_rows = poll_response.pages.total if poll_response.pages else None
+    all_rows: List[Dict[str, Any]] = list(poll_response.rows or [])
+    next_key = poll_response.pages.next_key if poll_response.pages else None
+
+    fetch_bar = _get_bar(
+        total=total_rows, desc="Fetching results", unit="rows", disable=not show_progress
+    )
+    try:
+        if fetch_bar is not None:
+            fetch_bar.update(len(all_rows))
+
+        while next_key:
+            page = service.query_relay.query.fetch_query_relay_results(
+                FetchQueryRelayResultsInput(
+                    token=token,
+                    page_size=page_size,
+                    next_page_token=next_key,
+                )
+            )
+            page_rows = page.rows or []
+            all_rows.extend(page_rows)
+            if fetch_bar is not None:
+                fetch_bar.update(len(page_rows))
+            next_key = page.pages.next_key if page.pages else None
+    finally:
+        if fetch_bar is not None:
+            fetch_bar.close()
+
+    return TaegisQueryRelayNormalizer(
+        raw_results=all_rows,
+        service="query_relay",
+        tenant_id=service.tenant_id,
+        region=service.environment,
+        arguments={
+            "cell": cell,
+            "time_range_start": time_range_start,
+            "time_range_end": time_range_end,
+            "workload": workload,
+            "page_size": page_size,
+            "tenant": tenant,
+            "region": region,
+        },
+    )

--- a/taegis_magic/magics.py
+++ b/taegis_magic/magics.py
@@ -14,6 +14,7 @@ from IPython.core.magic import Magics, line_cell_magic, line_magic, magics_class
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
 from IPython.display import display, display_markdown
 from jinja2 import TemplateSyntaxError
+from taegis_sdk_python import ServiceCoreException
 from taegis_sdk_python.config import get_config
 from taegis_sdk_python.templates import load_jinja2_template_environment
 
@@ -301,6 +302,8 @@ class TaegisMagics(Magics):
                 result = app(command_args, prog_name="taegis", standalone_mode=False)
             except (SystemExit, TransportQueryError) as e:
                 log.exception(f"Command execution failed: {type(e).__name__}: {e}")
+                result = None
+            except ServiceCoreException:
                 result = None
             # os.environ["TAEGIS_MAGIC_OUTPUT"] = "False"
 


### PR DESCRIPTION
This PR closes issue #133.

Adds a `taegis query` command wrapping Taegis Query Relay - submit a SQL cell, poll until execution completes, and paginate all result rows.

- New `taegis_magic/commands/query_relay.py`
- Registered in `taegis_magic/cli.py` as `taegis query`
- Checks `QueryRelayResponse.error` on the submission response so a rejected query (e.g. invalid SQL) surfaces immediately instead of polling with a dead token

**Verify:** `taegis query --cell "<sql>" --workload <workload> --tenant <id> --region <region>`