### PR TITLE
Issue 137: Update query_relay command for correlationId, EnrichOptions, optional workload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "taegis-sdk-python>=2.0,<3.0",
+    "taegis-sdk-python>=2.0.2,<3.0",
     "ipython",
     "notebook",
     "nbformat",

--- a/taegis_magic/commands/query_relay.py
+++ b/taegis_magic/commands/query_relay.py
@@ -12,6 +12,7 @@ from taegis_magic.core.normalizer import TaegisResultsNormalizer
 from taegis_magic.core.service import get_service
 from taegis_sdk_python import ServiceCoreException
 from taegis_sdk_python.services.query_relay.types import (
+    EnrichOptions,
     ExecuteQueryRelayInput,
     FetchQueryRelayResultsInput,
     QueryRelayResult,
@@ -48,6 +49,7 @@ class TaegisQueryRelayNormalizer(TaegisResultsNormalizer):
     """Taegis Query Relay Normalizer."""
 
     raw_results: List[Dict[str, Any]] = field(default_factory=list)
+    correlation_id: Optional[str] = None
 
     @property
     def results(self) -> List[Dict[str, Any]]:
@@ -58,7 +60,10 @@ class TaegisQueryRelayNormalizer(TaegisResultsNormalizer):
 @tracing
 def search(
     cell: Annotated[str, typer.Option(help="SQL query to execute")],
-    workload: Annotated[str, typer.Option(help="QEE workload type for Trino cluster routing")],
+    workload: Annotated[
+        Optional[str],
+        typer.Option(help="QEE workload type for Trino cluster routing (optional; QEE falls back to a default when omitted)"),
+    ] = None,
     time_range_start: Annotated[
         Optional[str], typer.Option(help="ISO8601 start time")
     ] = None,
@@ -66,6 +71,13 @@ def search(
         Optional[str], typer.Option(help="ISO8601 end time")
     ] = None,
     page_size: Annotated[int, typer.Option(help="Results per page")] = 1000,
+    no_enrich_hostname: Annotated[
+        bool,
+        typer.Option(
+            "--no-enrich-hostname",
+            help="Disable host_id to $hostname enrichment (enabled by default)",
+        ),
+    ] = False,
     tenant: Annotated[Optional[str], typer.Option(help="Tenant ID")] = None,
     region: Annotated[Optional[str], typer.Option(help="Taegis Region")] = None,
     progress: Annotated[bool, typer.Option(help="Show progress bars")] = True,
@@ -88,11 +100,14 @@ def search(
         error = response.error
         message = (
             f"Query Relay execution failed to start: {response.status} "
-            f"error={error.error} message={error.message} code={error.code}"
+            f"error={error.error} message={error.message} code={error.code} "
+            f"correlationId={response.correlation_id}"
         )
         log.error(message)
         raise ServiceCoreException(message)
-    log.info(f"Query submitted, token: {token}")
+    log.info(f"Query submitted, token: {token}, correlationId: {response.correlation_id}")
+
+    enrich = EnrichOptions(hostname=not no_enrich_hostname)
 
     # Phase 1: Poll until execution completes
     poll_bar = _get_bar(
@@ -101,7 +116,9 @@ def search(
     try:
         while True:
             poll_response = service.query_relay.query.fetch_query_relay_results(
-                FetchQueryRelayResultsInput(token=token, page_size=page_size)
+                FetchQueryRelayResultsInput(
+                    token=token, page_size=page_size, enrich=enrich
+                )
             )
             if poll_response.status == QueryRelayStatus.FINISHED:
                 if poll_bar is not None:
@@ -122,7 +139,8 @@ def search(
             f"Query Relay execution did not succeed: {poll_response.result} "
             f"error={error.error if error else None} "
             f"message={error.message if error else None} "
-            f"code={error.code if error else None}"
+            f"code={error.code if error else None} "
+            f"correlationId={poll_response.correlation_id}"
         )
         log.error(message)
         raise ServiceCoreException(message)
@@ -145,6 +163,7 @@ def search(
                     token=token,
                     page_size=page_size,
                     next_page_token=next_key,
+                    enrich=enrich,
                 )
             )
             page_rows = page.rows or []
@@ -158,6 +177,7 @@ def search(
 
     return TaegisQueryRelayNormalizer(
         raw_results=all_rows,
+        correlation_id=poll_response.correlation_id,
         service="query_relay",
         tenant_id=service.tenant_id,
         region=service.environment,
@@ -167,6 +187,7 @@ def search(
             "time_range_end": time_range_end,
             "workload": workload,
             "page_size": page_size,
+            "no_enrich_hostname": no_enrich_hostname,
             "tenant": tenant,
             "region": region,
         },


### PR DESCRIPTION
## Why
The `query search` command predates recent additions to the `query_relay` SDK service (correlationId for troubleshooting, EnrichOptions for hostname enrichment control, and an optional `workload` field). This PR brings the command up to date.

This PR closes #137.

## What changed
- `taegis_magic/commands/query_relay.py`:
  - Import `EnrichOptions`; add a single `--no-enrich-hostname` flag (default off, since the server already defaults enrichment on) and pass it consistently on both `FetchQueryRelayResultsInput` call sites (initial poll + pagination loop).
  - Surface `correlation_id` in the submit/poll log lines, in both error messages, and on the returned `TaegisQueryRelayNormalizer`.
  - Make `workload` optional (`Optional[str] = None`) to match the schema — the server already falls back to a default when it's omitted.
- `pyproject.toml`: bump the `taegis-sdk-python` dependency floor to `>=2.0.2,<3.0` — `2.0.2` is the first released version containing `correlation_id`/`EnrichOptions`; earlier `2.0.x` releases would fail at runtime.

## How to verify
- `python -m taegis_magic.cli query search --help` — confirms `--no-enrich-hostname` renders (no redundant `--enrich-hostname` pair), and `--workload` is no longer marked `[required]`.
- `from taegis_magic.commands import query_relay` — imports cleanly against `taegis-sdk-python>=2.0.2`.
- Ran an actual `query search` call against a live tenant to confirm `correlation_id` shows up in logs/errors and enrichment toggles as expected.