### PR TITLE
Issue 139: Display structured Query Relay validation errors

### DIFF
--- a/taegis_magic/commands/query_relay.py
+++ b/taegis_magic/commands/query_relay.py
@@ -7,10 +7,10 @@ from typing import Any, Dict, List, Optional
 
 import typer
 from dataclasses_json import dataclass_json
+from gql.transport.exceptions import TransportQueryError
 from taegis_magic.core.log import tracing
 from taegis_magic.core.normalizer import TaegisResultsNormalizer
 from taegis_magic.core.service import get_service
-from taegis_sdk_python import ServiceCoreException
 from taegis_sdk_python.services.query_relay.types import (
     EnrichOptions,
     ExecuteQueryRelayInput,
@@ -43,6 +43,22 @@ def _get_bar(total, desc, unit, disable=False):
     return None
 
 
+def _transport_error_details(error: TransportQueryError) -> Dict[str, Any]:
+    """Extract the first GraphQL error from a transport exception."""
+    payload = error.args[0] if error.args else {}
+    errors = getattr(error, "errors", None)
+    if not errors:
+        errors = payload if isinstance(payload, list) else [payload]
+    graphql_error = errors[0] if errors and isinstance(errors[0], dict) else {}
+    extensions = graphql_error.get("extensions") or {}
+    return {
+        "message": graphql_error.get("message") or str(error),
+        "path": ".".join(str(part) for part in graphql_error.get("path", [])),
+        "error_type": extensions.get("serviceName"),
+        "code": extensions.get("code"),
+    }
+
+
 @dataclass_json
 @dataclass
 class TaegisQueryRelayNormalizer(TaegisResultsNormalizer):
@@ -50,10 +66,21 @@ class TaegisQueryRelayNormalizer(TaegisResultsNormalizer):
 
     raw_results: List[Dict[str, Any]] = field(default_factory=list)
     correlation_id: Optional[str] = None
+    status: Optional[str] = None
+    result: Optional[str] = None
+    error_type: Optional[str] = None
+    message: Optional[str] = None
+    code: Optional[str] = None
+    path: Optional[str] = None
+    is_error: bool = False
 
     @property
     def results(self) -> List[Dict[str, Any]]:
         return self.raw_results
+
+    def _repr_markdown_(self):
+        """Represent as markdown."""
+        return self._display_template("taegis_query_relay_results.md.jinja")
 
 
 @app.command()
@@ -87,14 +114,35 @@ def search(
     show_progress = progress and tqdm is not None
 
     # Submit the query and get a token back
-    response = service.query_relay.mutation.execute_query_relay(
-        ExecuteQueryRelayInput(
-            sql=cell,
-            time_range_start=time_range_start,
-            time_range_end=time_range_end,
-            workload=workload,
+    try:
+        response = service.query_relay.mutation.execute_query_relay(
+            ExecuteQueryRelayInput(
+                sql=cell,
+                time_range_start=time_range_start,
+                time_range_end=time_range_end,
+                workload=workload,
+            )
         )
-    )
+    except TransportQueryError as exc:
+        error_details = _transport_error_details(exc)
+        log.error(
+            "Query Relay validation failed: message=%s code=%s path=%s",
+            error_details["message"],
+            error_details["code"],
+            error_details["path"],
+        )
+        return TaegisQueryRelayNormalizer(
+            service="query_relay",
+            tenant_id=service.tenant_id,
+            region=service.environment,
+            status="ERROR",
+            result="FAILED",
+            error_type=error_details["error_type"],
+            message=error_details["message"],
+            code=error_details["code"],
+            path=error_details["path"],
+            is_error=True,
+        )
     token = response.token
     if response.error:
         error = response.error
@@ -104,7 +152,17 @@ def search(
             f"correlationId={response.correlation_id}"
         )
         log.error(message)
-        raise ServiceCoreException(message)
+        return TaegisQueryRelayNormalizer(
+            service="query_relay",
+            tenant_id=service.tenant_id,
+            region=service.environment,
+            correlation_id=response.correlation_id,
+            status=response.status.value if response.status else None,
+            error_type=error.error,
+            message=error.message,
+            code=error.code,
+            is_error=True,
+        )
     log.info(f"Query submitted, token: {token}, correlationId: {response.correlation_id}")
 
     enrich = EnrichOptions(hostname=not no_enrich_hostname)
@@ -143,7 +201,18 @@ def search(
             f"correlationId={poll_response.correlation_id}"
         )
         log.error(message)
-        raise ServiceCoreException(message)
+        return TaegisQueryRelayNormalizer(
+            service="query_relay",
+            tenant_id=service.tenant_id,
+            region=service.environment,
+            correlation_id=poll_response.correlation_id,
+            status=poll_response.status.value if poll_response.status else None,
+            result=poll_response.result.value if poll_response.result else None,
+            error_type=error.error if error else None,
+            message=error.message if error else None,
+            code=error.code if error else None,
+            is_error=True,
+        )
 
     # Phase 2: Fetch all pages with progress
     total_rows = poll_response.pages.total if poll_response.pages else None
@@ -178,6 +247,8 @@ def search(
     return TaegisQueryRelayNormalizer(
         raw_results=all_rows,
         correlation_id=poll_response.correlation_id,
+        status=poll_response.status.value if poll_response.status else None,
+        result=poll_response.result.value if poll_response.result else None,
         service="query_relay",
         tenant_id=service.tenant_id,
         region=service.environment,

--- a/taegis_magic/magics.py
+++ b/taegis_magic/magics.py
@@ -320,6 +320,10 @@ class TaegisMagics(Magics):
             if not result:
                 return
 
+            if getattr(result, "is_error", False):
+                display(result, exclude=["text/plain"])
+                return
+
             self.shell.user_ns["_taegis_magic_result"] = result
             self.shell.user_ns["_taegis_magic_cell_contents"] = cell
 

--- a/taegis_magic/templates/taegis_query_relay_results.md.jinja
+++ b/taegis_magic/templates/taegis_query_relay_results.md.jinja
@@ -1,0 +1,25 @@
+**Taegis Results**
+
+{% if obj.is_error %}
+<div style="background-color: #f8d7da; border: 1px solid #f5c2c7; color: #842029; padding: 12px;">
+
+| Field | Value |
+|-------|-------|
+| Status | {{ obj.status }} |
+| Result | {{ obj.result }} |
+| Error Type | {{ obj.error_type }} |
+| Message | {{ obj.message }} |
+| Code | {{ obj.code }} |
+| Path | {{ obj.path }} |
+| Correlation ID | {{ obj.correlation_id }} |
+
+</div>
+{% else %}
+| Field | Value |
+|-------|-------|
+| Region | {{ obj.region }} |
+| Tenant | {{ obj.tenant_id }} |
+| Service | {{ obj.service }} |
+| Correlation ID | {{ obj.correlation_id }} |
+| Total Results | {{ obj.total_results|validate_int }} |
+{% endif %}


### PR DESCRIPTION
## Summary
- Return Query Relay execution-start and execution-complete failures as structured normalizers.
- Convert GraphQL validation `TransportQueryError` payloads into structured notebook errors.
- Render success and failure metadata as vertical field/value tables, with failures in a light-red panel.
- Display magic errors without assignment, append, caching, or display suppression.

Closes #139

## Verification
- Python source compilation passes.
- `git diff --check` passes.
- Notebook changes were intentionally excluded from the commit.
- Full pytest execution was unavailable locally because the environment lacks the project test dependencies.